### PR TITLE
Add deps to the app.src file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,13 @@
 PROJECT = katana_code
 
-DEPS = inaka_aleppo elvis_core
-TEST_DEPS = mixer
+DEPS = aleppo
+TEST_DEPS = mixer xref_runner
 SHELL_DEPS = sync
 BUILD_DEPS = inaka_mk hexer_mk
 LOCAL_DEPS = tools compiler syntax_tools common_test hipe
 
-dep_inaka_aleppo = hex 0.9.9
-dep_mixer        = git https://github.com/inaka/mixer.git 0.1.4
-dep_elvis_core   = git https://github.com/inaka/elvis_core.git efa6df5
+dep_aleppo       = git https://github.com/inaka/aleppo.git 0.9.10
+dep_mixer        = git https://github.com/inaka/mixer.git 0.1.5
 dep_sync         = git https://github.com/rustyio/sync.git 9c78e7b
 dep_inaka_mk     = git https://github.com/inaka/inaka.mk.git 1.0.0
 dep_hexer_mk     = git https://github.com/inaka/hexer.mk.git 1.1.0

--- a/src/katana_code.app.src
+++ b/src/katana_code.app.src
@@ -2,7 +2,7 @@
  [
   {description, "Functions useful for processing Erlang code."},
   {vsn, "0.0.2"},
-  {applications, [kernel, stdlib]},
+  {applications, [kernel, stdlib, aleppo]},
   {modules, []},
   {registered, []},
   {maintainers, ["Inaka"]},


### PR DESCRIPTION
In this PR, I…
- Added `aleppo` to app.src, then I noticed many other deps were downloaded on `make all`
- Removed `elvis_core` from `DEPS`, then the tests failed because of missing functions
- Added `xref_runner` to the `TEST_DEPS`, but tests keep failing because of a missing module: `ktn_lists`
- Not to bring the whole `erlang-katana` project as a dep since we just needed one function, I copied the function