### PR TITLE
Add API to provide file name for `parse_tree`

### DIFF
--- a/src/ktn_code.erl
+++ b/src/ktn_code.erl
@@ -8,6 +8,7 @@
          beam_to_erl/2,
          parse_tree/1,
          parse_tree/2,
+         parse_tree/3,
          eval/1,
          consult/1,
          to_str/1
@@ -91,13 +92,23 @@ beam_to_erl(BeamPath, ErlPath) ->
 parse_tree(Source) ->
     parse_tree([], Source).
 
-%% @doc Parses code in a string or binary format and returns the parse tree.
 -spec parse_tree([string()], string() | binary()) -> tree_node().
 parse_tree(IncludeDirs, Source) ->
+    parse_tree(IncludeDirs, undefined, Source).
+
+%% @doc Parses code in a string or binary format and returns the parse tree.
+-spec parse_tree([string()],
+                 file:name_all() | undefined,
+                 string() | binary()) -> tree_node().
+parse_tree(IncludeDirs, FileName, Source) ->
     SourceStr = to_str(Source),
     ScanOpts = [text, return_comments],
     {ok, Tokens, _} = erl_scan:string(SourceStr, {1, 1}, ScanOpts),
-    Options = [{include, IncludeDirs}],
+    Options0 = [{include, IncludeDirs}],
+    Options = case FileName of
+                  undefined -> Options0;
+                  _ -> [{file, FileName} | Options0]
+              end,
     {ok, NewTokens} = aleppo:process_tokens(Tokens, Options),
 
     IsComment = fun


### PR DESCRIPTION
aleppo does better job when it knows file name (eg, '?FILE' macro and
relative includes)

This one intended to be used with https://github.com/inaka/aleppo/pull/46, so, if that one will be merged and new tag will be pushed, it would be nice to upgrade `aleppo` dependency as well.