### PR TITLE
[#30] Don't show private functions in documentation

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -56,7 +56,8 @@
 
 %% == EDoc ==
 
-{edoc_opts, [ {private, true}
+{edoc_opts, [ {private, false}
+            , {hidden, false}
             , {todo, true}
             ]}.
 


### PR DESCRIPTION
This PR adds the required `edoc_opts` to hide the private functions in the generated docs.