### PR TITLE
[Fix #41] Parse stringyfied macros

### DIFF
--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -827,7 +827,7 @@ rewrite(Node) ->
                     N = erl_syntax:copy_pos(Node, erl_syntax:atom(A1)),
                     erl_syntax:copy_pos(Node, erl_syntax:macro(N));
                 ?var_prefix ++ As ->
-                    A1 = list_to_atom([$?|As]),
+                    A1 = list_to_atom(As),
                     N = erl_syntax:copy_pos(Node, erl_syntax:variable(A1)),
                     erl_syntax:copy_pos(Node, erl_syntax:macro(N));
                 _ ->
@@ -885,12 +885,14 @@ fix_stringyfied_macros(Ts) ->
 
 fix_stringyfied_macros([], Ts) -> lists:reverse(Ts);
 fix_stringyfied_macros([{'?', Pos}, {atom, Pos, MacroName} | Rest], Ts) ->
-    case atom_to_list(MacroName) of
-        ?var_prefix ++ _ ->
-            fix_stringyfied_macros(Rest, [{atom, Pos, MacroName} | Ts]);
-        _ ->
-            fix_stringyfied_macros(Rest, [{atom, Pos, MacroName}, {'?', Pos} | Ts])
-    end;
+    NextTs =
+        case atom_to_list(MacroName) of
+            ?var_prefix ++ Name ->
+                [{atom, Pos, list_to_atom(?var_prefix ++ [$?|Name])} | Ts];
+            _ ->
+                [{atom, Pos, MacroName}, {'?', Pos} | Ts]
+        end,
+    fix_stringyfied_macros(Rest, NextTs);
 fix_stringyfied_macros([Other|Rest], Ts) ->
     fix_stringyfied_macros(Rest, [Other|Ts]).
 

--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -887,7 +887,7 @@ fix_stringyfied_macros([], Ts) -> lists:reverse(Ts);
 fix_stringyfied_macros([{'?', Pos}, {atom, Pos, BadMacroName} | Rest], Ts) ->
     MacroName =
         case atom_to_list(BadMacroName) of
-            "?," ++ Name -> list_to_atom("??" ++ Name);
+            "?," ++ Name -> list_to_atom("? ?" ++ Name);
             _ -> BadMacroName
         end,
     fix_stringyfied_macros(Rest, [{atom, Pos, MacroName} | Ts]);


### PR DESCRIPTION
This PR fixes #41 and allow us to parse stuff like `??MODULE`.