### PR TITLE
[Fix #49] Don't preprocess macros if we're not going to parse them later

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,5 @@
 %% -*- mode: erlang;erlang-indent-level: 2;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
-
 {erl_opts, [ warn_unused_vars
            , warn_export_all
            , warn_shadow_vars
@@ -35,14 +34,14 @@
            , {plt_extra_apps, [tools, syntax_tools]}
            , {plt_location, local}
            , {base_plt_apps, [stdlib, kernel]}
-           , {base_plt_location, global}]}.
+           , {base_plt_location, global}
+           ]}.
 
-{xref_checks,[
-    undefined_function_calls,
-    locals_not_used,
-    deprecated_function_calls,
-    deprecated_functions
-]}.
+{xref_checks,[ undefined_function_calls
+             , locals_not_used
+             , deprecated_function_calls
+             , deprecated_functions
+             ]}.
 
 {project_plugins, [rebar3_hex, rebar3_lint]}.
 

--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -673,6 +673,9 @@ normal_parser(Ts0, Opt) ->
             Node
     end.
 
+scan_form([{'-', _L}, {atom, La, define} | Ts], #opt{parse_macro_definitions = false}) ->
+    [{atom, La, ?pp_form}, {'(', La}, {')', La}, {'->', La},
+     {atom, La, define} | Ts];
 scan_form([{'-', _L}, {atom, La, define} | Ts], Opt) ->
     [{atom, La, ?pp_form}, {'(', La}, {')', La}, {'->', La},
      {atom, La, define} | scan_macros(Ts, Opt)];


### PR DESCRIPTION
[Fix #49] Don't preprocess macros if we're not going to parse them later