### PR TITLE
Compact strings directly when parsing, to preserve original formatting

### DIFF
--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -511,7 +511,6 @@ parse_tokens(Ts, PreFix, PostFix) ->
         {form, Form} ->
             Form;
         {retry, Ts1} ->
-            erlang:display(Ts1),
             parse_tokens(Ts1, PreFix, PostFix);
         no_fix ->
             case erl_parse:parse_form(Ts) of


### PR DESCRIPTION
This basically turns…
```erlang
{ string
, [ {text,"\"a\""}
  , {location,4}
  ]
, "ab\n    cd"
}
```
…into…
```erlang
{ string
, [ {text,"\"a\" \"b\n    c\"\n\"d\""}
  , {location,4}
  ]
, "ab\n    cd"
}
```
…when parsing…
```erlang
    "a" "b
    c"
    "d".
```

This will eventually help with AdRoll/rebar3_format#55.