### PR TITLE
Fix #60: Handle parsing of none-module files

### DIFF
--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -539,10 +539,8 @@ parse_tokens_as_terms(Ts, PreFix, PostFix) ->
             parse_tokens_as_terms(Ts1, PreFix, PostFix);
         no_fix ->
             case erl_parse:parse_exprs(Ts) of
-                {ok, [Form]} ->
-                    Form;
                 {ok, Forms} ->
-                    erl_syntax:form_list(Forms);
+                    erl_syntax:form_list(Forms ++ [erl_syntax:text(".")]);
                 {error, IoErr} ->
                     case PostFix(Ts) of
                         {form, Form} ->

--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -540,7 +540,7 @@ parse_tokens_as_terms(Ts, PreFix, PostFix) ->
         no_fix ->
             case erl_parse:parse_exprs(Ts) of
                 {ok, Forms} ->
-                    erl_syntax:form_list(Forms ++ [erl_syntax:text(".")]);
+                    erl_syntax:form_list(Forms ++ [floating_dot()]);
                 {error, IoErr} ->
                     case PostFix(Ts) of
                         {form, Form} ->
@@ -552,6 +552,9 @@ parse_tokens_as_terms(Ts, PreFix, PostFix) ->
                     end
             end
     end.
+
+floating_dot() ->
+    erl_syntax:set_ann(erl_syntax:text("."), floating_dot).
 
 %% ---------------------------------------------------------------------
 %% Quick scanning/parsing - deletes macro definitions and other

--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -516,12 +516,39 @@ parse_tokens(Ts, PreFix, PostFix) ->
             case erl_parse:parse_form(Ts) of
                 {ok, Form} ->
                     Form;
-                {error, IoErr} ->
+                {error, _IoErr} ->
                     case PostFix(Ts) of
                         {form, Form} ->
                             Form;
                         {retry, Ts1, PostFix1} ->
                             parse_tokens(Ts1, PreFix, PostFix1);
+                        no_fix ->
+                            parse_tokens_as_terms(Ts, PreFix, PostFix)
+                    end
+            end
+    end.
+
+%% @doc This handles config files, app.src, etc.
+%%      PreFix adjusts the tokens before parsing them.
+%%      PostFix adjusts the tokens after parsing them, only if erl_parse failed.
+parse_tokens_as_terms(Ts, PreFix, PostFix) ->
+    case PreFix(Ts) of
+        {form, Form} ->
+            Form;
+        {retry, Ts1} ->
+            parse_tokens_as_terms(Ts1, PreFix, PostFix);
+        no_fix ->
+            case erl_parse:parse_exprs(Ts) of
+                {ok, [Form]} ->
+                    Form;
+                {ok, Forms} ->
+                    erl_syntax:form_list(Forms);
+                {error, IoErr} ->
+                    case PostFix(Ts) of
+                        {form, Form} ->
+                            Form;
+                        {retry, Ts1, PostFix1} ->
+                            parse_tokens_as_terms(Ts1, PreFix, PostFix1);
                         no_fix ->
                             throw({parse_error, IoErr})
                     end

--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -554,7 +554,7 @@ parse_tokens_as_terms(Ts, PreFix, PostFix) ->
     end.
 
 expression_dot() ->
-    erl_syntax:set_ann(erl_syntax:text("."), expression_dot).
+    erl_syntax:set_ann(erl_syntax:text("."), [expression_dot]).
 
 %% ---------------------------------------------------------------------
 %% Quick scanning/parsing - deletes macro definitions and other

--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -540,7 +540,7 @@ parse_tokens_as_terms(Ts, PreFix, PostFix) ->
         no_fix ->
             case erl_parse:parse_exprs(Ts) of
                 {ok, Forms} ->
-                    erl_syntax:form_list(Forms ++ [floating_dot()]);
+                    erl_syntax:form_list(Forms ++ [expression_dot()]);
                 {error, IoErr} ->
                     case PostFix(Ts) of
                         {form, Form} ->
@@ -553,8 +553,8 @@ parse_tokens_as_terms(Ts, PreFix, PostFix) ->
             end
     end.
 
-floating_dot() ->
-    erl_syntax:set_ann(erl_syntax:text("."), floating_dot).
+expression_dot() ->
+    erl_syntax:set_ann(erl_syntax:text("."), expression_dot).
 
 %% ---------------------------------------------------------------------
 %% Quick scanning/parsing - deletes macro definitions and other


### PR DESCRIPTION
Fix #60: Handle parsing of none-module files