### PR TITLE
Fix the optional else block parse in maybe syntax.

### DIFF
--- a/src/ktn_code.erl
+++ b/src/ktn_code.erl
@@ -430,6 +430,12 @@ to_map({try_after, Attrs, AfterBody}) ->
     #{type => try_after,
       attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
       content => to_map(AfterBody)};
+%% maybe..end
+to_map({'maybe', Attrs, Body}) ->
+    MaybeBody = to_map(Body),
+    #{type => 'maybe',
+      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+      content => MaybeBody};
 %% maybe..else..end
 to_map({'maybe', Attrs, Body, Else}) ->
     MaybeBody = to_map(Body),

--- a/test/ktn_code_SUITE.erl
+++ b/test/ktn_code_SUITE.erl
@@ -6,7 +6,7 @@
 
 -if(?OTP_RELEASE >= 25).
 
--export([parse_maybe/1]).
+-export([parse_maybe/1, parse_maybe_else/1]).
 
 -endif.
 
@@ -116,6 +116,16 @@ to_string(_Config) ->
 
 -spec parse_maybe(config()) -> ok.
 parse_maybe(_Config) ->
+    %% Note that to pass this test case, the 'maybe_expr' feature must be enabled.
+    #{type := root,
+      content :=
+          [#{type := function, content := [#{type := clause, content := [#{type := 'maybe'}]}]}]} =
+        ktn_code:parse_tree(<<"foo() -> maybe ok ?= ok end.">>),
+
+    ok.
+
+-spec parse_maybe_else(config()) -> ok.
+parse_maybe_else(_Config) ->
     %% Note that to pass this test case, the 'maybe_expr' feature must be enabled.
     #{type := root,
       content :=


### PR DESCRIPTION
The `else` clause is optional in the `maybe` syntax.