### PR TITLE
Un-break katana for projects that do not enable maybe_expr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
@@ -34,6 +34,8 @@ jobs:
       run: ERL_FLAGS="-enable-feature all" rebar3 compile
     - name: Format check
       run: ERL_FLAGS="-enable-feature all" rebar3 format --verify
-    - name: Run tests and verifications
+    - name: Run tests and verifications (features not enabled)
+      run: rebar3 test
+    - name: Run tests and verifications (features enabled)
       run: ERL_FLAGS="-enable-feature all" rebar3 test
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,13 +1,7 @@
 %% -*- mode: erlang;erlang-indent-level: 2;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
 {erl_opts,
- [warn_unused_import,
-  warn_export_vars,
-  warnings_as_errors,
-  verbose,
-  report,
-  debug_info,
-  {feature, maybe_expr, enable}]}.
+ [warn_unused_import, warn_export_vars, warnings_as_errors, verbose, report, debug_info]}.
 
 {minimum_otp_vsn, "23"}.
 


### PR DESCRIPTION
  * Check state of maybe_expr feature when test is run, with a small shim to handle pre-25 otp.
  * In ci workflow, test both with and without -enable-feature all.
  * Use `runs-on: ubuntu-20.04` in ci.yml, as ubuntu-latest is now 22.04, which drops otp 23