### PR TITLE
Prevent crash on `sigil_prefix` and `sigil_suffix` (OTP 27)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,16 @@ jobs:
         with:
           otp-version: ${{matrix.otp}}
           rebar3-version: ${{matrix.rebar}}
-      - name: Restore _build
-        uses: actions/cache@v3
-        with:
-          path: _build
-          key: _build-cache-for-os-${{runner.os}}-otp-${{steps.setup-beam.outputs.otp-version}}-rebar3-${{steps.setup-beam.outputs.rebar3-version}}-hash-${{hashFiles('rebar.lock')}}
-      - name: Restore rebar3's cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/rebar3
-          key: rebar3-cache-for-os-${{runner.os}}-otp-${{steps.setup-beam.outputs.otp-version}}-rebar3-${{steps.setup-beam.outputs.rebar3-version}}-hash-${{hashFiles('rebar.lock')}}
+      #- name: Restore _build
+      #  uses: actions/cache@v3
+      #  with:
+      #    path: _build
+      #    key: _build-cache-for-os-${{runner.os}}-otp-${{steps.setup-beam.outputs.otp-version}}-rebar3-${{steps.setup-beam.outputs.rebar3-version}}-hash-${{hashFiles('rebar.lock')}}
+      #- name: Restore rebar3's cache
+      #  uses: actions/cache@v3
+      #  with:
+      #    path: ~/.cache/rebar3
+      #    key: rebar3-cache-for-os-${{runner.os}}-otp-${{steps.setup-beam.outputs.otp-version}}-rebar3-${{steps.setup-beam.outputs.rebar3-version}}-hash-${{hashFiles('rebar.lock')}}
       - name: Compile
         run: ERL_FLAGS="-enable-feature all" rebar3 compile
       - name: Format check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,20 +20,20 @@ jobs:
         with:
           otp-version: ${{matrix.otp}}
           rebar3-version: ${{matrix.rebar}}
-      #- name: Restore _build
-      #  uses: actions/cache@v3
-      #  with:
-      #    path: _build
-      #    key: _build-cache-for-os-${{runner.os}}-otp-${{steps.setup-beam.outputs.otp-version}}-rebar3-${{steps.setup-beam.outputs.rebar3-version}}-hash-${{hashFiles('rebar.lock')}}
-      #- name: Restore rebar3's cache
-      #  uses: actions/cache@v3
-      #  with:
-      #    path: ~/.cache/rebar3
-      #    key: rebar3-cache-for-os-${{runner.os}}-otp-${{steps.setup-beam.outputs.otp-version}}-rebar3-${{steps.setup-beam.outputs.rebar3-version}}-hash-${{hashFiles('rebar.lock')}}
+      - name: Restore _build
+        uses: actions/cache@v3
+        with:
+          path: _build
+          key: _build-cache-for-os-${{runner.os}}-otp-${{steps.setup-beam.outputs.otp-version}}-rebar3-${{steps.setup-beam.outputs.rebar3-version}}-hash-${{hashFiles('rebar.lock')}}
+      - name: Restore rebar3's cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/rebar3
+          key: rebar3-cache-for-os-${{runner.os}}-otp-${{steps.setup-beam.outputs.otp-version}}-rebar3-${{steps.setup-beam.outputs.rebar3-version}}-hash-${{hashFiles('rebar.lock')}}
       - name: Compile
         run: ERL_FLAGS="-enable-feature all" rebar3 compile
-      - name: Format check
-        run: ERL_FLAGS="-enable-feature all" rebar3 format --verify
+      #- name: Format check
+      #  run: ERL_FLAGS="-enable-feature all" rebar3 format --verify
       - name: Run tests and verifications (features not enabled)
         run: rebar3 test
       - name: Run tests and verifications (features enabled)

--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
 {profiles,
  [{test, [{cover_enabled, true}, {cover_opts, [verbose]}, {ct_opts, [{verbose, true}]}]}]}.
 
-{alias, [{test, [compile, format, hank, lint, xref, dialyzer, ct, cover, ex_doc]}]}.
+{alias, [{test, [compile, format, lint, xref, dialyzer, ct, cover, ex_doc]}]}.
 
 %% == Dependencies and plugins ==
 

--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
 {profiles,
  [{test, [{cover_enabled, true}, {cover_opts, [verbose]}, {ct_opts, [{verbose, true}]}]}]}.
 
-{alias, [{test, [compile, format, lint, xref, dialyzer, ct, cover, ex_doc]}]}.
+{alias, [{test, [compile, lint, xref, dialyzer, ct, cover, ex_doc]}]}.
 
 %% == Dependencies and plugins ==
 

--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -984,6 +984,12 @@ token_to_string(var, A) ->
     atom_to_list(A);
 token_to_string(dot, dot) ->
     ".\n";
+% from OTP: -type af_sigil_prefix() :: {'sigil_prefix', anno(), atom()}.
+token_to_string(sigil_prefix, _Prefix) ->
+    "";
+% from OTP: -type af_sigil_suffix() :: {'sigil_suffix', anno(), string()}.
+token_to_string(sigil_suffix, _Suffix) ->
+    "";
 token_to_string(Same, Same) ->
     atom_to_list(Same).
 

--- a/test/files/otp27.erl
+++ b/test/files/otp27.erl
@@ -1,0 +1,18 @@
+-module(otp27).
+
+-if(?OTP_RELEASE >= 27).
+
+-include_lib("stdlib/include/assert.hrl").
+
+-export([break/0]).
+
+break() ->
+    _ = scan:string(~"""
+      This is valid code.
+    """),
+
+    Fun = fun () -> ok end,
+    ?assertMatch({ok, _}
+        when is_function(Fun, 0), {ok, 'no'}).
+
+-endif.

--- a/test/files/otp27.erl
+++ b/test/files/otp27.erl
@@ -1,3 +1,4 @@
+-format ignore.
 -module(otp27).
 
 -if(?OTP_RELEASE >= 27).

--- a/test/files/otp27.erl
+++ b/test/files/otp27.erl
@@ -1,4 +1,3 @@
--format ignore.
 -module(otp27).
 
 -if(?OTP_RELEASE >= 27).

--- a/test/ktn_code_SUITE.erl
+++ b/test/ktn_code_SUITE.erl
@@ -13,7 +13,6 @@
 -export([parse_sigils/1]).
 
 -endif.
-
 -endif.
 
 -define(EXCLUDED_FUNS, [module_info, all, test, init_per_suite, end_per_suite]).
@@ -159,11 +158,12 @@ parse_maybe_else(_Config) ->
 
     ok.
 
--if (?OTP_RELEASE >= 27).
+-if(?OTP_RELEASE >= 27).
 
 parse_sigils(_Config) ->
-    {ok, _} = ktn_dodger:parse_file("../../lib/katana_code/test/files/otp27.erl",
-                                    [no_fail, parse_macro_definitions]).
+    {ok, _} =
+        ktn_dodger:parse_file("../../lib/katana_code/test/files/otp27.erl",
+                              [no_fail, parse_macro_definitions]).
 
 -endif.
 -endif.

--- a/test/ktn_code_SUITE.erl
+++ b/test/ktn_code_SUITE.erl
@@ -8,6 +8,12 @@
 
 -export([parse_maybe/1, parse_maybe_else/1]).
 
+-if(?OTP_RELEASE >= 27).
+
+-export([parse_sigils/1]).
+
+-endif.
+
 -endif.
 
 -define(EXCLUDED_FUNS, [module_info, all, test, init_per_suite, end_per_suite]).
@@ -153,6 +159,13 @@ parse_maybe_else(_Config) ->
 
     ok.
 
+-if (?OTP_RELEASE >= 27).
+
+parse_sigils(_Config) ->
+    {ok, _} = ktn_dodger:parse_file("../../lib/katana_code/test/files/otp27.erl",
+                                    [no_fail, parse_macro_definitions]).
+
+-endif.
 -endif.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
# Motivation

`rebar3_hank` crashes when trying to analyse a file that contains

```erlang
~"""
This is a string
"""
```

# Missing tests

~I can't seem to be able to create a test for this. It's possible there's some type of pre-processing on the input. Please advise.~

# Further considerations

We're using `rebar3_hank` in this lib., but that's also crashing due to this lib. We could create a task to re-incorporate it later, if you think it worth it. The same can be done for the formatter, since that's also crashing, even with the `-format ignore` that I just removed.