### PR TITLE
Support OTP 28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,9 @@ jobs:
           key: rebar3-cache-for-os-${{runner.os}}-otp-${{steps.setup-beam.outputs.otp-version}}-rebar3-${{steps.setup-beam.outputs.rebar3-version}}-hash-${{hashFiles('rebar.lock')}}
       - name: Compile
         run: ERL_FLAGS="-enable-feature all" rebar3 compile
-      #- name: Format check
-      #  run: ERL_FLAGS="-enable-feature all" rebar3 format --verify
+      - name: Format check
+        if: matrix.otp == '28'
+        run: rebar3 fmt --check
       - name: Run tests and verifications (features not enabled)
         run: rebar3 test
       - name: Run tests and verifications (features enabled)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
           key: rebar3-cache-for-os-${{runner.os}}-otp-${{steps.setup-beam.outputs.otp-version}}-rebar3-${{steps.setup-beam.outputs.rebar3-version}}-hash-${{hashFiles('rebar.lock')}}
       - name: Compile
         run: ERL_FLAGS="-enable-feature all" rebar3 compile
-      #- name: Format check
-      #  if: matrix.otp == '28'
-      #  run: rebar3 fmt --check
+      - name: Format check
+        if: matrix.otp == '27'
+        run: rebar3 fmt --check
       - name: Run tests and verifications (features not enabled)
         run: rebar3 test
       - name: Run tests and verifications (features enabled)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,19 +14,19 @@ jobs:
         rebar: ['3.25']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         id: setup-beam
         with:
           otp-version: ${{matrix.otp}}
           rebar3-version: ${{matrix.rebar}}
       - name: Restore _build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: _build
           key: _build-cache-for-os-${{runner.os}}-otp-${{steps.setup-beam.outputs.otp-version}}-rebar3-${{steps.setup-beam.outputs.rebar3-version}}-hash-${{hashFiles('rebar.lock')}}
       - name: Restore rebar3's cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/rebar3
           key: rebar3-cache-for-os-${{runner.os}}-otp-${{steps.setup-beam.outputs.otp-version}}-rebar3-${{steps.setup-beam.outputs.rebar3-version}}-hash-${{hashFiles('rebar.lock')}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
 
     strategy:
       matrix:
-        otp: ['25', '26', '27']
-        rebar: ['3.24']
+        otp: ['26', '27', '28']
+        rebar: ['3.25']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
           key: rebar3-cache-for-os-${{runner.os}}-otp-${{steps.setup-beam.outputs.otp-version}}-rebar3-${{steps.setup-beam.outputs.rebar3-version}}-hash-${{hashFiles('rebar.lock')}}
       - name: Compile
         run: ERL_FLAGS="-enable-feature all" rebar3 compile
-      - name: Format check
-        if: matrix.otp == '28'
-        run: rebar3 fmt --check
+      #- name: Format check
+      #  if: matrix.otp == '28'
+      #  run: rebar3 fmt --check
       - name: Run tests and verifications (features not enabled)
         run: rebar3 test
       - name: Run tests and verifications (features enabled)

--- a/elvis.config
+++ b/elvis.config
@@ -1,10 +1,20 @@
-[{elvis,
-  [{config,
-    [#{dirs => ["src"],
-       filter => "*.erl",
-       ruleset => erl_files,
-       rules => [{elvis_style, atom_naming_convention, #{regex => "^([a-z][A-Za-z0-9]*_?)*$"}}]},
-     #{dirs => ["test"],
-       filter => "*.erl",
-       ruleset => erl_files,
-       rules => [{elvis_style, no_debug_call, disable}]}]}]}].
+[
+    {elvis, [
+        {config, [
+            #{
+                dirs => ["src"],
+                filter => "*.erl",
+                ruleset => erl_files,
+                rules => [
+                    {elvis_style, atom_naming_convention, #{regex => "^([a-z][A-Za-z0-9]*_?)*$"}}
+                ]
+            },
+            #{
+                dirs => ["test"],
+                filter => "*.erl",
+                ruleset => erl_files,
+                rules => [{elvis_style, no_debug_call, disable}]
+            }
+        ]}
+    ]}
+].

--- a/rebar.config
+++ b/rebar.config
@@ -1,31 +1,31 @@
 %% == Compiler and Profiles ==
 
-{erl_opts,
- [warn_unused_import, warn_export_vars, warnings_as_errors, verbose, report, debug_info]}.
+{erl_opts, [warn_unused_import, warn_export_vars, warnings_as_errors, verbose, report, debug_info]}.
 
 {minimum_otp_vsn, "26"}.
 
-{profiles,
- [{test, [{cover_enabled, true}, {cover_opts, [verbose]}, {ct_opts, [{verbose, true}]}]}]}.
+{profiles, [{test, [{cover_enabled, true}, {cover_opts, [verbose]}, {ct_opts, [{verbose, true}]}]}]}.
 
 {alias, [{test, [compile, fmt, lint, xref, dialyzer, ct, cover]}]}.
 
 %% == Dependencies and plugins ==
 
-{project_plugins,
- [{rebar3_hank, "~> 1.4.0"},
-  {rebar3_hex, "~> 7.0.7"},
-  {erlfmt, "~> 1.6.2"},
-  {rebar3_lint, "~> 3.1.0"},
-  {rebar3_ex_doc, "~> 0.2.20"}]}.
+{project_plugins, [
+    {rebar3_hank, "~> 1.4.0"},
+    {rebar3_hex, "~> 7.0.7"},
+    {erlfmt, "~> 1.6.2"},
+    {rebar3_lint, "~> 3.1.0"},
+    {rebar3_ex_doc, "~> 0.2.20"}
+]}.
 
 %% == Documentation ==
 
-{ex_doc,
- [{source_url, <<"https://github.com/inaka/katana-code">>},
-  {extras, [<<"README.md">>, <<"LICENSE">>]},
-  {main, <<"README.md">>},
-  {prefix_ref_vsn_with_v, false}]}.
+{ex_doc, [
+    {source_url, <<"https://github.com/inaka/katana-code">>},
+    {extras, [<<"README.md">>, <<"LICENSE">>]},
+    {main, <<"README.md">>},
+    {prefix_ref_vsn_with_v, false}
+]}.
 
 {hex, [{doc, #{provider => ex_doc}}]}.
 
@@ -38,11 +38,11 @@
 
 %% == Dialyzer + XRef ==
 
-{dialyzer,
- [{warnings, [no_return, unmatched_returns, error_handling, underspecs, unknown]},
-  {plt_extra_apps, [syntax_tools, common_test]}]}.
+{dialyzer, [
+    {warnings, [no_return, unmatched_returns, error_handling, underspecs, unknown]},
+    {plt_extra_apps, [syntax_tools, common_test]}
+]}.
 
-{xref_checks,
- [undefined_function_calls, deprecated_function_calls, deprecated_functions]}.
+{xref_checks, [undefined_function_calls, deprecated_function_calls, deprecated_functions]}.
 
 {xref_extra_paths, ["test/**"]}.

--- a/rebar.config
+++ b/rebar.config
@@ -8,14 +8,14 @@
 {profiles,
  [{test, [{cover_enabled, true}, {cover_opts, [verbose]}, {ct_opts, [{verbose, true}]}]}]}.
 
-{alias, [{test, [compile, lint, xref, dialyzer, ct, cover]}]}.
+{alias, [{test, [compile, fmt, lint, xref, dialyzer, ct, cover]}]}.
 
 %% == Dependencies and plugins ==
 
 {project_plugins,
  [{rebar3_hank, "~> 1.4.0"},
   {rebar3_hex, "~> 7.0.7"},
-  {rebar3_format, "~> 1.3.0"},
+  {erlfmt, "~> 1.6.2"},
   {rebar3_lint, "~> 3.1.0"},
   {rebar3_ex_doc, "~> 0.2.20"}]}.
 
@@ -31,7 +31,10 @@
 
 %% == Format ==
 
-{format, [{options, #{unquote_atoms => false}}]}.
+{erlfmt, [
+    write,
+    {files, ["src/**/*.app.src", "src/**/*.erl", "test/**/*.erl", "*.config"]}
+]}.
 
 %% == Dialyzer + XRef ==
 

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 
 {profiles, [{test, [{cover_enabled, true}, {cover_opts, [verbose]}, {ct_opts, [{verbose, true}]}]}]}.
 
-{alias, [{test, [compile, fmt, lint, xref, dialyzer, ct, cover]}]}.
+{alias, [{test, [compile, lint, xref, dialyzer, ct, cover]}]}.
 
 %% == Dependencies and plugins ==
 

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts,
  [warn_unused_import, warn_export_vars, warnings_as_errors, verbose, report, debug_info]}.
 
-{minimum_otp_vsn, "25"}.
+{minimum_otp_vsn, "26"}.
 
 {profiles,
  [{test, [{cover_enabled, true}, {cover_opts, [verbose]}, {ct_opts, [{verbose, true}]}]}]}.

--- a/src/katana_code.app.src
+++ b/src/katana_code.app.src
@@ -1,10 +1,10 @@
-{application,
- katana_code,
- [{description, "Functions useful for processing Erlang code."},
-  {vsn, git},
-  {applications, [kernel, stdlib]},
-  {modules, []},
-  {registered, []},
-  {licenses, ["Apache 2.0"]},
-  {links, [{"GitHub", "https://github.com/inaka/katana-code"}]},
-  {build_tools, ["rebar3"]}]}.
+{application, katana_code, [
+    {description, "Functions useful for processing Erlang code."},
+    {vsn, git},
+    {applications, [kernel, stdlib]},
+    {modules, []},
+    {registered, []},
+    {licenses, ["Apache 2.0"]},
+    {links, [{"GitHub", "https://github.com/inaka/katana-code"}]},
+    {build_tools, ["rebar3"]}
+]}.

--- a/src/ktn_code.erl
+++ b/src/ktn_code.erl
@@ -20,11 +20,11 @@
     b_generate | b_generate_strict | bc | bc_expr | binary | binary_element | block | call |
     callback | case_clauses | case_expr | char | clause | comment | cons | default | define |
     else_attr | export | float | function | generate | generate_strict | if_attr | import |
-    integer | lc | lc_expr | m_generate | macro | map | map_field_assoc | map_field_exact | match |
-    maybe_match | mc | mc_expr | module | named_fun | nil | nominal | op | opaque | query |
-    receive_after | receive_case | record | record_attr | record_field | record_index | remote |
-    remote_type | root | spec | string | try_after | try_case | try_catch | tuple | type |
-    type_attr | type_map_field | typed_record_field | user_type | var | atom().
+    integer | lc | lc_expr | m_generate | m_generate_strict | macro | map | map_field_assoc |
+    map_field_exact | match | maybe_match | mc | mc_expr | module | named_fun | nil | nominal |
+    op | opaque | query | receive_after | receive_case | record | record_attr | record_field |
+    record_index | remote | remote_type | root | spec | string | try_after | try_case | try_catch |
+    tuple | type | type_attr | type_map_field | typed_record_field | user_type | var | atom().
 -type tree_node() ::
     #{type => tree_node_type(),
       attrs => map(),
@@ -580,6 +580,10 @@ to_map({mc, Anno, RepE0, RepQs}) ->
       content => [McExpr | McGenerators]};
 to_map({m_generate, Anno, Pattern, RepE0}) ->
     #{type => m_generate,
+      attrs => #{location => get_location(Anno), text => get_text(Anno)},
+      node_attrs => #{pattern => to_map(Pattern), expression => to_map(RepE0)}};
+to_map({m_generate_strict, Anno, Pattern, RepE0}) ->
+    #{type => m_generate_strict,
       attrs => #{location => get_location(Anno), text => get_text(Anno)},
       node_attrs => #{pattern => to_map(Pattern), expression => to_map(RepE0)}};
 to_map({mc_expr, Anno, RepE0}) ->

--- a/src/ktn_code.erl
+++ b/src/ktn_code.erl
@@ -24,7 +24,7 @@
     map_field_exact | match | maybe_match | mc | mc_expr | module | named_fun | nil | nominal |
     op | opaque | query | receive_after | receive_case | record | record_attr | record_field |
     record_index | remote | remote_type | root | spec | string | try_after | try_case | try_catch |
-    tuple | type | type_attr | type_map_field | typed_record_field | user_type | var | atom().
+    tuple | type | type_attr | type_map_field | typed_record_field | user_type | var | zip | atom().
 -type tree_node() ::
     #{type => tree_node_type(),
       attrs => map(),
@@ -533,6 +533,13 @@ to_map({Type, Attrs, Key, Value}) when map_field_exact == Type; map_field_assoc 
     #{type => Type,
       attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
       node_attrs => #{key => to_map(Key), value => to_map(Value)}};
+%% Comprehensions - all
+to_map({zip, Attrs, Generators}) ->
+    #{type => zip,
+      attrs =>
+          #{location => get_location(Attrs),
+            text => get_text(Attrs),
+            generators => [to_map(Generator) || Generator <- Generators]}};
 %% List Comprehension
 to_map({lc, Attrs, Expr, GeneratorsFilters}) ->
     LcExpr = to_map({lc_expr, Attrs, Expr}),

--- a/src/ktn_code.erl
+++ b/src/ktn_code.erl
@@ -622,17 +622,6 @@ to_map({Type, Attrs, Key, Value}) when map_field_exact == Type; map_field_assoc 
         attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
         node_attrs => #{key => to_map(Key), value => to_map(Value)}
     };
-%% Comprehensions - all
-to_map({zip, Attrs, Generators}) ->
-    #{
-        type => zip,
-        attrs =>
-            #{
-                location => get_location(Attrs),
-                text => get_text(Attrs),
-                generators => [to_map(Generator) || Generator <- Generators]
-            }
-    };
 %% List Comprehension
 to_map({lc, Attrs, Expr, GeneratorsFilters}) ->
     LcExpr = to_map({lc_expr, Attrs, Expr}),
@@ -647,6 +636,16 @@ to_map({generate, Attrs, Pattern, Expr}) ->
         type => generate,
         attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
         node_attrs => #{pattern => to_map(Pattern), expression => to_map(Expr)}
+    };
+to_map({zip, Attrs, Generators}) ->
+    #{
+        type => zip,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                generators => [to_map(Generator) || Generator <- Generators]
+            }
     };
 to_map({generate_strict, Attrs, Pattern, Expr}) ->
     #{

--- a/src/ktn_code.erl
+++ b/src/ktn_code.erl
@@ -12,22 +12,8 @@
 
 -export_type([tree_node/0, tree_node_type/0, beam_lib_beam/0]).
 
-%% erlfmt:ignore-begin
 %% NOTE: we use atom() below, because erl_scan:category() is not exported.
-%%       In fact, this type ends up being just atom() for dialyzer,
-%%       since it has too many options and it's compressed.
--type tree_node_type() ::
-    'case' | 'catch' | 'else' | 'fun' | 'if' | 'maybe' | 'receive' | 'try' | any | atom |
-    b_generate | b_generate_strict | bc | bc_expr | binary | binary_element | block | call |
-    callback | case_clauses | case_expr | char | clause | comment | cons | default | define |
-    else_attr | export | float | function | generate | generate_strict | if_attr | import |
-    integer | lc | lc_expr | m_generate | m_generate_strict | macro | map | map_field_assoc |
-    map_field_exact | match | maybe_match | mc | mc_expr | module | named_fun | nil | nominal |
-    op | opaque | query | receive_after | receive_case | record | record_attr | record_field |
-    record_index | remote | remote_type | root | spec | string | try_after | try_case | try_catch |
-    tuple | type | type_attr | type_map_field | typed_record_field | user_type | var | zip | error |
-    warning | eof | atom().
-%% erlfmt:ignore-end
+-type tree_node_type() :: atom().
 -type tree_node() ::
     #{
         type => tree_node_type(),

--- a/src/ktn_code.erl
+++ b/src/ktn_code.erl
@@ -25,7 +25,8 @@
     map_field_exact | match | maybe_match | mc | mc_expr | module | named_fun | nil | nominal |
     op | opaque | query | receive_after | receive_case | record | record_attr | record_field |
     record_index | remote | remote_type | root | spec | string | try_after | try_case | try_catch |
-    tuple | type | type_attr | type_map_field | typed_record_field | user_type | var | zip | atom().
+    tuple | type | type_attr | type_map_field | typed_record_field | user_type | var | zip | error |
+    warning | eof | atom().
 %% erlfmt:ignore-end
 -type tree_node() ::
     #{
@@ -1006,6 +1007,28 @@ to_map({macro, Attrs, Name, Args}) ->
                 name => NameStr
             },
         content => to_map(Args1)
+    };
+%% Representation of Parse Errors and End-of-File
+to_map({error, E}) ->
+    #{
+        type => error,
+        attrs => #{
+            value => E
+        }
+    };
+to_map({warning, W}) ->
+    #{
+        type => warning,
+        attrs => #{
+            value => W
+        }
+    };
+to_map({eof, Location}) ->
+    #{
+        type => eof,
+        attrs => #{
+            location => get_location(Location)
+        }
     };
 %% Unhandled forms
 to_map(Parsed) when is_tuple(Parsed) ->

--- a/src/ktn_code.erl
+++ b/src/ktn_code.erl
@@ -28,10 +28,12 @@
     tuple | type | type_attr | type_map_field | typed_record_field | user_type | var | zip | atom().
 %% erlfmt:ignore-end
 -type tree_node() ::
-    #{type => tree_node_type(),
-      attrs => map(),
-      node_attrs => map(),
-      content => [tree_node()]}.
+    #{
+        type => tree_node_type(),
+        attrs => map(),
+        node_attrs => map(),
+        content => [tree_node()]
+    }.
 -type beam_lib_beam() :: file:filename() | binary().
 % Should eventually become beam_lib:beam(), once that's exposed
 % (https://github.com/erlang/otp/pull/7534)
@@ -39,15 +41,11 @@
 % Should eventually become erl_syntax:annotation_or_location(), once that's exposed
 % (https://github.com/erlang/otp/pull/7535)
 -type erl_parse_foo() ::
-    {attribute,
-     Pos :: erl_syntax_annotation_or_location(),
-     Name :: erl_syntax:syntaxTree(),
-     Args :: none | [erl_syntax:syntaxTree()]} |
-    {macro,
-     Pos :: erl_syntax_annotation_or_location(),
-     Name :: erl_syntax:syntaxTree(),
-     Args :: none | [erl_syntax:syntaxTree()]} |
-    {atom, [{node, Node :: erl_syntax:syntaxTree()}], non_reversible_form}.
+    {attribute, Pos :: erl_syntax_annotation_or_location(), Name :: erl_syntax:syntaxTree(),
+        Args :: none | [erl_syntax:syntaxTree()]}
+    | {macro, Pos :: erl_syntax_annotation_or_location(), Name :: erl_syntax:syntaxTree(),
+        Args :: none | [erl_syntax:syntaxTree()]}
+    | {atom, [{node, Node :: erl_syntax:syntaxTree()}], non_reversible_form}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Exported API
@@ -61,7 +59,8 @@ beam_to_string(BeamPath) ->
     case beam_lib:chunks(BeamPath, [abstract_code]) of
         {ok, {_, [{abstract_code, {raw_abstract_v1, Forms}}]}} ->
             Src = erl_prettypr:format(
-                      erl_syntax:form_list(tl(Forms))),
+                erl_syntax:form_list(tl(Forms))
+            ),
             {ok, Src};
         Error ->
             Error
@@ -94,14 +93,18 @@ parse_tree(Source) ->
 
     Comments = lists:filter(fun is_comment/1, Tokens),
     Children =
-        [to_map(Form)
+        [
+            to_map(Form)
          || Form <- Forms,
             %% filter forms that couldn't be parsed
-            element(1, Form) =/= error],
+            element(1, Form) =/= error
+        ],
 
-    #{type => root,
-      attrs => #{tokens => lists:map(fun token_to_map/1, Tokens)},
-      content => to_map(Comments) ++ Children}.
+    #{
+        type => root,
+        attrs => #{tokens => lists:map(fun token_to_map/1, Tokens)},
+        content => to_map(Comments) ++ Children
+    }.
 
 -spec is_comment(erl_scan:token()) -> boolean().
 is_comment({comment, _, _}) ->
@@ -132,8 +135,10 @@ revert(attribute, Node0) ->
     Node = erl_syntax:update_tree(Node0, Gs),
 
     Name =
-        try erl_syntax:atom_value(
-                erl_syntax:attribute_name(Node))
+        try
+            erl_syntax:atom_value(
+                erl_syntax:attribute_name(Node)
+            )
         of
             'if' ->
                 if_attr;
@@ -190,14 +195,14 @@ consult(Source) ->
     Forms = split_when(fun is_dot/1, Tokens),
     ParseFun =
         fun(Form) ->
-           {ok, Expr} = erl_parse:parse_exprs(Form),
-           Expr
+            {ok, Expr} = erl_parse:parse_exprs(Form),
+            Expr
         end,
     Parsed = lists:map(ParseFun, Forms),
     ExprsFun =
         fun(P) ->
-           {value, Value, _} = erl_eval:exprs(P, []),
-           Value
+            {value, Value, _} = erl_eval:exprs(P, []),
+            Value
         end,
     lists:map(ExprsFun, Parsed).
 
@@ -310,416 +315,602 @@ get_text(_Attrs) ->
 to_map(ListParsed) when is_list(ListParsed) ->
     lists:map(fun to_map/1, ListParsed);
 to_map({function, Attrs, Name, Arity, Clauses}) ->
-    #{type => function,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            name => Name,
-            arity => Arity},
-      content => to_map(Clauses)};
+    #{
+        type => function,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                name => Name,
+                arity => Arity
+            },
+        content => to_map(Clauses)
+    };
 to_map({function, Name, Arity}) ->
     #{type => function, attrs => #{name => Name, arity => Arity}};
 to_map({function, Module, Name, Arity}) ->
-    #{type => function,
-      attrs =>
-          #{module => Module,
-            name => Name,
-            arity => Arity}};
+    #{
+        type => function,
+        attrs =>
+            #{
+                module => Module,
+                name => Name,
+                arity => Arity
+            }
+    };
 to_map({clause, Attrs, Patterns, Guards, Body}) ->
-    #{type => clause,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      node_attrs => #{pattern => to_map(Patterns), guards => to_map(Guards)},
-      content => to_map(Body)};
+    #{
+        type => clause,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        node_attrs => #{pattern => to_map(Patterns), guards => to_map(Guards)},
+        content => to_map(Body)
+    };
 to_map({match, Attrs, Left, Right}) ->
-    #{type => match,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => to_map([Left, Right])};
+    #{
+        type => match,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => to_map([Left, Right])
+    };
 to_map({maybe_match, Attrs, Left, Right}) ->
-    #{type => maybe_match,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => to_map([Left, Right])};
+    #{
+        type => maybe_match,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => to_map([Left, Right])
+    };
 to_map({tuple, Attrs, Elements}) ->
-    #{type => tuple,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => to_map(Elements)};
+    #{
+        type => tuple,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => to_map(Elements)
+    };
 %% Literals
-to_map({Type, Attrs, Value})
-    when Type == atom; Type == integer; Type == float; Type == string; Type == char ->
-    #{type => Type,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            value => Value}};
+to_map({Type, Attrs, Value}) when
+    Type == atom; Type == integer; Type == float; Type == string; Type == char
+->
+    #{
+        type => Type,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                value => Value
+            }
+    };
 to_map({bin, Attrs, Elements}) ->
-    #{type => binary,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => to_map(Elements)};
+    #{
+        type => binary,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => to_map(Elements)
+    };
 to_map({bin_element, Attrs, Value, Size, TSL}) ->
-    #{type => binary_element,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            type_spec_list => TSL},
-      node_attrs =>
-          #{value => to_map(Value),
-            size =>
-                case Size of
-                    default ->
-                        #{type => default};
-                    _ ->
-                        to_map(Size)
-                end}};
+    #{
+        type => binary_element,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                type_spec_list => TSL
+            },
+        node_attrs =>
+            #{
+                value => to_map(Value),
+                size =>
+                    case Size of
+                        default ->
+                            #{type => default};
+                        _ ->
+                            to_map(Size)
+                    end
+            }
+    };
 %% Variables
 to_map({var, Attrs, Name}) ->
-    #{type => var,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            name => Name}};
+    #{
+        type => var,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                name => Name
+            }
+    };
 %% Function call
 to_map({call, Attrs, Function, Arguments}) ->
-    #{type => call,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      node_attrs => #{function => to_map(Function)},
-      content => to_map(Arguments)};
+    #{
+        type => call,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        node_attrs => #{function => to_map(Function)},
+        content => to_map(Arguments)
+    };
 to_map({remote, Attrs, Module, Function}) ->
-    #{type => remote,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      node_attrs => #{module => to_map(Module), function => to_map(Function)}};
+    #{
+        type => remote,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        node_attrs => #{module => to_map(Module), function => to_map(Function)}
+    };
 %% case
 to_map({'case', Attrs, Expr, Clauses}) ->
     CaseExpr = to_map({case_expr, Attrs, Expr}),
     CaseClauses = to_map({case_clauses, Attrs, Clauses}),
-    #{type => 'case',
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      node_attrs => #{expression => to_map(Expr)},
-      content => [CaseExpr, CaseClauses]};
+    #{
+        type => 'case',
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        node_attrs => #{expression => to_map(Expr)},
+        content => [CaseExpr, CaseClauses]
+    };
 to_map({case_expr, Attrs, Expr}) ->
-    #{type => case_expr,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => [to_map(Expr)]};
+    #{
+        type => case_expr,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => [to_map(Expr)]
+    };
 to_map({case_clauses, Attrs, Clauses}) ->
-    #{type => case_clauses,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => to_map(Clauses)};
+    #{
+        type => case_clauses,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => to_map(Clauses)
+    };
 %% fun
 to_map({'fun', Attrs, {function, Name, Arity}}) ->
-    #{type => 'fun',
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            name => Name,
-            arity => Arity}};
+    #{
+        type => 'fun',
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                name => Name,
+                arity => Arity
+            }
+    };
 to_map({'fun', Attrs, {function, Module, Name, Arity}}) ->
-    #{type => 'fun',
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            module => Module,
-            name => Name,
-            arity => Arity}};
+    #{
+        type => 'fun',
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                module => Module,
+                name => Name,
+                arity => Arity
+            }
+    };
 to_map({'fun', Attrs, {clauses, Clauses}}) ->
-    #{type => 'fun',
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => to_map(Clauses)};
+    #{
+        type => 'fun',
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => to_map(Clauses)
+    };
 to_map({named_fun, Attrs, Name, Clauses}) ->
-    #{type => named_fun,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            name => Name},
-      content => to_map(Clauses)};
+    #{
+        type => named_fun,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                name => Name
+            },
+        content => to_map(Clauses)
+    };
 %% query - deprecated, implemented for completion.
 to_map({query, Attrs, ListCompr}) ->
-    #{type => query,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => to_map(ListCompr)};
+    #{
+        type => query,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => to_map(ListCompr)
+    };
 %% try..catch..after
 to_map({'try', Attrs, Body, [], CatchClauses, AfterBody}) ->
     TryBody = to_map(Body),
     TryCatch = to_map({try_catch, Attrs, CatchClauses}),
     TryAfter = to_map({try_after, Attrs, AfterBody}),
 
-    #{type => 'try',
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      node_attrs => #{catch_clauses => to_map(CatchClauses), after_body => to_map(AfterBody)},
-      content => TryBody ++ [TryCatch, TryAfter]};
+    #{
+        type => 'try',
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        node_attrs => #{catch_clauses => to_map(CatchClauses), after_body => to_map(AfterBody)},
+        content => TryBody ++ [TryCatch, TryAfter]
+    };
 %% try..of..catch..after
 to_map({'try', Attrs, Expr, CaseClauses, CatchClauses, AfterBody}) ->
     TryCase = to_map({try_case, Attrs, Expr, CaseClauses}),
     TryCatch = to_map({try_catch, Attrs, CatchClauses}),
     TryAfter = to_map({try_after, Attrs, AfterBody}),
 
-    #{type => 'try',
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => [TryCase, TryCatch, TryAfter]};
+    #{
+        type => 'try',
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => [TryCase, TryCatch, TryAfter]
+    };
 to_map({try_case, Attrs, Expr, Clauses}) ->
-    #{type => try_case,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      node_attrs => #{expression => to_map(Expr)},
-      content => to_map(Clauses)};
+    #{
+        type => try_case,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        node_attrs => #{expression => to_map(Expr)},
+        content => to_map(Clauses)
+    };
 to_map({try_catch, Attrs, Clauses}) ->
-    #{type => try_catch,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => to_map(Clauses)};
+    #{
+        type => try_catch,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => to_map(Clauses)
+    };
 to_map({try_after, Attrs, AfterBody}) ->
-    #{type => try_after,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => to_map(AfterBody)};
+    #{
+        type => try_after,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => to_map(AfterBody)
+    };
 %% maybe..end
 to_map({'maybe', Attrs, Body}) ->
     MaybeBody = to_map(Body),
-    #{type => 'maybe',
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => MaybeBody};
+    #{
+        type => 'maybe',
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => MaybeBody
+    };
 %% maybe..else..end
 to_map({'maybe', Attrs, Body, Else}) ->
     MaybeBody = to_map(Body),
     MaybeElse = to_map(Else),
-    #{type => 'maybe',
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => MaybeBody ++ [MaybeElse]};
+    #{
+        type => 'maybe',
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => MaybeBody ++ [MaybeElse]
+    };
 to_map({'else', Attrs, Clauses}) ->
-    #{type => 'else',
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => to_map(Clauses)};
+    #{
+        type => 'else',
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => to_map(Clauses)
+    };
 %% if
 to_map({'if', Attrs, IfClauses}) ->
-    #{type => 'if',
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => to_map(IfClauses)};
+    #{
+        type => 'if',
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => to_map(IfClauses)
+    };
 %% catch
 to_map({'catch', Attrs, Expr}) ->
-    #{type => 'catch',
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => [to_map(Expr)]};
+    #{
+        type => 'catch',
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => [to_map(Expr)]
+    };
 %% receive
 to_map({'receive', Attrs, Clauses}) ->
     RecClauses = to_map({receive_case, Attrs, Clauses}),
-    #{type => 'receive',
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => [RecClauses]};
+    #{
+        type => 'receive',
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => [RecClauses]
+    };
 to_map({'receive', Attrs, Clauses, AfterExpr, AfterBody}) ->
     RecClauses = to_map({receive_case, Attrs, Clauses}),
     RecAfter = to_map({receive_after, Attrs, AfterExpr, AfterBody}),
-    #{type => 'receive',
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => [RecClauses, RecAfter]};
+    #{
+        type => 'receive',
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => [RecClauses, RecAfter]
+    };
 to_map({receive_case, Attrs, Clauses}) ->
-    #{type => receive_case,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => to_map(Clauses)};
+    #{
+        type => receive_case,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => to_map(Clauses)
+    };
 to_map({receive_after, Attrs, Expr, Body}) ->
-    #{type => receive_after,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      node_attrs => #{expression => to_map(Expr)},
-      content => to_map(Body)};
+    #{
+        type => receive_after,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        node_attrs => #{expression => to_map(Expr)},
+        content => to_map(Body)
+    };
 %% List
 to_map({nil, Attrs}) ->
     #{type => nil, attrs => #{location => get_location(Attrs), text => get_text(Attrs)}};
 to_map({cons, Attrs, Head, Tail}) ->
-    #{type => cons,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => [to_map(Head), to_map(Tail)]};
+    #{
+        type => cons,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => [to_map(Head), to_map(Tail)]
+    };
 %% Map
 to_map({map, Attrs, Pairs}) ->
-    #{type => map,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => to_map(Pairs)};
+    #{
+        type => map,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => to_map(Pairs)
+    };
 to_map({map, Attrs, Var, Pairs}) ->
-    #{type => map,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      node_attrs => #{var => to_map(Var)},
-      content => to_map(Pairs)};
+    #{
+        type => map,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        node_attrs => #{var => to_map(Var)},
+        content => to_map(Pairs)
+    };
 to_map({Type, Attrs, Key, Value}) when map_field_exact == Type; map_field_assoc == Type ->
-    #{type => Type,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      node_attrs => #{key => to_map(Key), value => to_map(Value)}};
+    #{
+        type => Type,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        node_attrs => #{key => to_map(Key), value => to_map(Value)}
+    };
 %% Comprehensions - all
 to_map({zip, Attrs, Generators}) ->
-    #{type => zip,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            generators => [to_map(Generator) || Generator <- Generators]}};
+    #{
+        type => zip,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                generators => [to_map(Generator) || Generator <- Generators]
+            }
+    };
 %% List Comprehension
 to_map({lc, Attrs, Expr, GeneratorsFilters}) ->
     LcExpr = to_map({lc_expr, Attrs, Expr}),
     LcGenerators = to_map(GeneratorsFilters),
-    #{type => lc,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => [LcExpr | LcGenerators]};
+    #{
+        type => lc,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => [LcExpr | LcGenerators]
+    };
 to_map({generate, Attrs, Pattern, Expr}) ->
-    #{type => generate,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      node_attrs => #{pattern => to_map(Pattern), expression => to_map(Expr)}};
+    #{
+        type => generate,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        node_attrs => #{pattern => to_map(Pattern), expression => to_map(Expr)}
+    };
 to_map({generate_strict, Attrs, Pattern, Expr}) ->
-    #{type => generate_strict,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      node_attrs => #{pattern => to_map(Pattern), expression => to_map(Expr)}};
+    #{
+        type => generate_strict,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        node_attrs => #{pattern => to_map(Pattern), expression => to_map(Expr)}
+    };
 to_map({lc_expr, Attrs, Expr}) ->
-    #{type => lc_expr,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => [to_map(Expr)]};
+    #{
+        type => lc_expr,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => [to_map(Expr)]
+    };
 %% Binary Comprehension
 to_map({bc, Attrs, Expr, GeneratorsFilters}) ->
     BcExpr = to_map({bc_expr, Attrs, Expr}),
     BcGenerators = to_map(GeneratorsFilters),
-    #{type => bc,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => [BcExpr | BcGenerators]};
+    #{
+        type => bc,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => [BcExpr | BcGenerators]
+    };
 to_map({b_generate, Attrs, Pattern, Expr}) ->
-    #{type => b_generate,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      node_attrs => #{pattern => to_map(Pattern), expression => to_map(Expr)}};
+    #{
+        type => b_generate,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        node_attrs => #{pattern => to_map(Pattern), expression => to_map(Expr)}
+    };
 to_map({b_generate_strict, Attrs, Pattern, Expr}) ->
-    #{type => b_generate_strict,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      node_attrs => #{pattern => to_map(Pattern), expression => to_map(Expr)}};
+    #{
+        type => b_generate_strict,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        node_attrs => #{pattern => to_map(Pattern), expression => to_map(Expr)}
+    };
 to_map({bc_expr, Attrs, Expr}) ->
-    #{type => bc_expr,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => [to_map(Expr)]};
+    #{
+        type => bc_expr,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => [to_map(Expr)]
+    };
 %% Map Comprehension
 to_map({mc, Anno, RepE0, RepQs}) ->
     McExpr = to_map({mc_expr, Anno, RepE0}),
     McGenerators = to_map(RepQs),
-    #{type => mc,
-      attrs => #{location => get_location(Anno), text => get_text(Anno)},
-      content => [McExpr | McGenerators]};
+    #{
+        type => mc,
+        attrs => #{location => get_location(Anno), text => get_text(Anno)},
+        content => [McExpr | McGenerators]
+    };
 to_map({m_generate, Anno, Pattern, RepE0}) ->
-    #{type => m_generate,
-      attrs => #{location => get_location(Anno), text => get_text(Anno)},
-      node_attrs => #{pattern => to_map(Pattern), expression => to_map(RepE0)}};
+    #{
+        type => m_generate,
+        attrs => #{location => get_location(Anno), text => get_text(Anno)},
+        node_attrs => #{pattern => to_map(Pattern), expression => to_map(RepE0)}
+    };
 to_map({m_generate_strict, Anno, Pattern, RepE0}) ->
-    #{type => m_generate_strict,
-      attrs => #{location => get_location(Anno), text => get_text(Anno)},
-      node_attrs => #{pattern => to_map(Pattern), expression => to_map(RepE0)}};
+    #{
+        type => m_generate_strict,
+        attrs => #{location => get_location(Anno), text => get_text(Anno)},
+        node_attrs => #{pattern => to_map(Pattern), expression => to_map(RepE0)}
+    };
 to_map({mc_expr, Anno, RepE0}) ->
-    #{type => mc_expr,
-      attrs => #{location => get_location(Anno), text => get_text(Anno)},
-      content => [to_map(RepE0)]};
+    #{
+        type => mc_expr,
+        attrs => #{location => get_location(Anno), text => get_text(Anno)},
+        content => [to_map(RepE0)]
+    };
 %% Operation
 to_map({op, Attrs, Operation, Left, Right}) ->
-    #{type => op,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            operation => Operation},
-      content => to_map([Left, Right])};
+    #{
+        type => op,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                operation => Operation
+            },
+        content => to_map([Left, Right])
+    };
 to_map({op, Attrs, Operation, Single}) ->
-    #{type => op,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            operation => Operation},
-      content => to_map([Single])};
+    #{
+        type => op,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                operation => Operation
+            },
+        content => to_map([Single])
+    };
 %% Record
 to_map({record, Attrs, Name, Fields}) ->
-    #{type => record,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            name => Name},
-      content => to_map(Fields)};
+    #{
+        type => record,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                name => Name
+            },
+        content => to_map(Fields)
+    };
 to_map({record, Attrs, Var, Name, Fields}) ->
-    #{type => record,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            name => Name},
-      node_attrs => #{variable => to_map(Var)},
-      content => to_map(Fields)};
+    #{
+        type => record,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                name => Name
+            },
+        node_attrs => #{variable => to_map(Var)},
+        content => to_map(Fields)
+    };
 to_map({record_index, Attrs, Name, Field}) ->
-    #{type => record_index,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            name => Name},
-      content => [to_map(Field)]};
+    #{
+        type => record_index,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                name => Name
+            },
+        content => [to_map(Field)]
+    };
 to_map({record_field, Attrs, Name}) ->
-    #{type => record_field,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      node_attrs => #{name => to_map(Name)}};
+    #{
+        type => record_field,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        node_attrs => #{name => to_map(Name)}
+    };
 to_map({record_field, Attrs, Name, Default}) ->
-    #{type => record_field,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      node_attrs => #{default => to_map(Default), name => to_map(Name)}};
+    #{
+        type => record_field,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        node_attrs => #{default => to_map(Default), name => to_map(Name)}
+    };
 to_map({record_field, Attrs, Var, Name, Field}) ->
-    #{type => record_field,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            name => Name},
-      node_attrs => #{variable => to_map(Var)},
-      content => [to_map(Field)]};
+    #{
+        type => record_field,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                name => Name
+            },
+        node_attrs => #{variable => to_map(Var)},
+        content => [to_map(Field)]
+    };
 %% Block
 to_map({block, Attrs, Body}) ->
-    #{type => block,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      content => to_map(Body)};
+    #{
+        type => block,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        content => to_map(Body)
+    };
 %% Record Attribute
 to_map({attribute, Attrs, record, {Name, Fields}}) ->
-    #{type => record_attr,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            name => Name},
-      content => to_map(Fields)};
+    #{
+        type => record_attr,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                name => Name
+            },
+        content => to_map(Fields)
+    };
 to_map({typed_record_field, Field, Type}) ->
     FieldMap = to_map(Field),
-    #{type => typed_record_field,
-      attrs =>
-          #{location => attr(location, FieldMap),
-            text => attr(text, FieldMap),
-            field => FieldMap},
-      node_attrs => #{type => to_map(Type)}};
+    #{
+        type => typed_record_field,
+        attrs =>
+            #{
+                location => attr(location, FieldMap),
+                text => attr(text, FieldMap),
+                field => FieldMap
+            },
+        node_attrs => #{type => to_map(Type)}
+    };
 %% Type
 to_map({type, Attrs, 'fun', Types}) ->
-    #{type => type,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            name => 'fun'},
-      content => to_map(Types)};
+    #{
+        type => type,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                name => 'fun'
+            },
+        content => to_map(Types)
+    };
 to_map({type, Attrs, constraint, [Sub, SubType]}) ->
-    #{type => type,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            name => constraint,
-            subtype => Sub},
-      content => to_map(SubType)};
+    #{
+        type => type,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                name => constraint,
+                subtype => Sub
+            },
+        content => to_map(SubType)
+    };
 to_map({type, Attrs, bounded_fun, [FunType, Defs]}) ->
-    #{type => type,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            name => bounded_fun},
-      node_attrs => #{'fun' => to_map(FunType)},
-      content => to_map(Defs)};
+    #{
+        type => type,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                name => bounded_fun
+            },
+        node_attrs => #{'fun' => to_map(FunType)},
+        content => to_map(Defs)
+    };
 to_map({type, Attrs, Name, any}) ->
     to_map({type, Attrs, Name, [any]});
 to_map({type, Attrs, any}) ->
-    #{type => type,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => "...",
-            name => '...'}};
+    #{
+        type => type,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => "...",
+                name => '...'
+            }
+    };
 to_map({type, Attrs, Name, Types}) ->
-    #{type => type,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            name => Name},
-      content => to_map(Types)};
-to_map({user_type, Attrs, Name, Types}) -> %% any()
-    #{type => user_type,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            name => Name},
-      content => to_map(Types)};
+    #{
+        type => type,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                name => Name
+            },
+        content => to_map(Types)
+    };
+%% any()
+to_map({user_type, Attrs, Name, Types}) ->
+    #{
+        type => user_type,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                name => Name
+            },
+        content => to_map(Types)
+    };
 to_map({type, Attrs, map_field_assoc, Name, Type}) ->
     {Location, Text} =
         case Attrs of
@@ -728,48 +919,71 @@ to_map({type, Attrs, map_field_assoc, Name, Type}) ->
             Attrs ->
                 {get_location(Attrs), get_text(Attrs)}
         end,
-    #{type => type_map_field,
-      attrs => #{location => Location, text => Text},
-      node_attrs => #{key => to_map(Name), type => to_map(Type)}};
+    #{
+        type => type_map_field,
+        attrs => #{location => Location, text => Text},
+        node_attrs => #{key => to_map(Name), type => to_map(Type)}
+    };
 to_map({remote_type, Attrs, [Module, Function, Args]}) ->
-    #{type => remote_type,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      node_attrs =>
-          #{module => to_map(Module),
-            function => to_map(Function),
-            args => to_map(Args)}};
+    #{
+        type => remote_type,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        node_attrs =>
+            #{
+                module => to_map(Module),
+                function => to_map(Function),
+                args => to_map(Args)
+            }
+    };
 to_map({ann_type, Attrs, [Var, Type]}) ->
-    #{type => record_field,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      node_attrs => #{var => to_map(Var), type => to_map(Type)}};
+    #{
+        type => record_field,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        node_attrs => #{var => to_map(Var), type => to_map(Type)}
+    };
 to_map({paren_type, Attrs, [Type]}) ->
-    #{type => record_field,
-      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
-      node_attrs => #{type => to_map(Type)}};
-to_map(any) -> %% any()
+    #{
+        type => record_field,
+        attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+        node_attrs => #{type => to_map(Type)}
+    };
+%% any()
+to_map(any) ->
     #{type => any};
 %% Other Attributes
 to_map({attribute, Attrs, type, {Name, Type, Args}}) ->
-    #{type => type_attr,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            name => Name},
-      node_attrs => #{args => to_map(Args), type => to_map(Type)}};
+    #{
+        type => type_attr,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                name => Name
+            },
+        node_attrs => #{args => to_map(Args), type => to_map(Type)}
+    };
 to_map({attribute, Attrs, spec, {{Name, Arity}, Types}}) ->
-    #{type => spec,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            name => Name,
-            arity => Arity},
-      node_attrs => #{types => to_map(Types)}};
+    #{
+        type => spec,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                name => Name,
+                arity => Arity
+            },
+        node_attrs => #{types => to_map(Types)}
+    };
 to_map({attribute, Attrs, Type, Value}) ->
-    #{type => Type,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs),
-            value => Value}};
+    #{
+        type => Type,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs),
+                value => Value
+            }
+    };
 %% Comments
 to_map({comment, Attrs, _Text}) ->
     #{type => comment, attrs => #{location => get_location(Attrs), text => get_text(Attrs)}};
@@ -783,12 +997,16 @@ to_map({macro, Attrs, Name, Args}) ->
                 Args
         end,
     NameStr = macro_name(Name),
-    #{type => macro,
-      attrs =>
-          #{location => get_location(Attrs),
-            text => get_text(Attrs) ++ NameStr,
-            name => NameStr},
-      content => to_map(Args1)};
+    #{
+        type => macro,
+        attrs =>
+            #{
+                location => get_location(Attrs),
+                text => get_text(Attrs) ++ NameStr,
+                name => NameStr
+            },
+        content => to_map(Args1)
+    };
 %% Unhandled forms
 to_map(Parsed) when is_tuple(Parsed) ->
     case erl_syntax:is_tree(Parsed) of

--- a/src/ktn_code.erl
+++ b/src/ktn_code.erl
@@ -12,6 +12,7 @@
 
 -export_type([tree_node/0, tree_node_type/0, beam_lib_beam/0]).
 
+%% erlfmt:ignore-begin
 %% NOTE: we use atom() below, because erl_scan:category() is not exported.
 %%       In fact, this type ends up being just atom() for dialyzer,
 %%       since it has too many options and it's compressed.
@@ -25,6 +26,7 @@
     op | opaque | query | receive_after | receive_case | record | record_attr | record_field |
     record_index | remote | remote_type | root | spec | string | try_after | try_case | try_catch |
     tuple | type | type_attr | type_map_field | typed_record_field | user_type | var | zip | atom().
+%% erlfmt:ignore-end
 -type tree_node() ::
     #{type => tree_node_type(),
       attrs => map(),

--- a/src/ktn_code.erl
+++ b/src/ktn_code.erl
@@ -17,14 +17,14 @@
 %%       since it has too many options and it's compressed.
 -type tree_node_type() ::
     'case' | 'catch' | 'else' | 'fun' | 'if' | 'maybe' | 'receive' | 'try' | any | atom |
-    b_generate | bc | bc_expr | binary | binary_element | block | call | callback |
-    case_clauses | case_expr | char | clause | comment | cons | default | define | else_attr |
-    export | float | function | generate | if_attr | import | integer | lc | lc_expr |
-    m_generate | macro | map | map_field_assoc | map_field_exact | match | maybe_match | mc |
-    mc_expr | module | named_fun | nil | nominal | op | opaque | query | receive_after |
-    receive_case | record | record_attr | record_field | record_index | remote | remote_type |
-    root | spec | string | try_after | try_case | try_catch | tuple | type | type_attr |
-    type_map_field | typed_record_field | user_type | var | atom().
+    b_generate | b_generate_strict | bc | bc_expr | binary | binary_element | block | call |
+    callback | case_clauses | case_expr | char | clause | comment | cons | default | define |
+    else_attr | export | float | function | generate | generate_strict | if_attr | import |
+    integer | lc | lc_expr | m_generate | macro | map | map_field_assoc | map_field_exact | match |
+    maybe_match | mc | mc_expr | module | named_fun | nil | nominal | op | opaque | query |
+    receive_after | receive_case | record | record_attr | record_field | record_index | remote |
+    remote_type | root | spec | string | try_after | try_case | try_catch | tuple | type |
+    type_attr | type_map_field | typed_record_field | user_type | var | atom().
 -type tree_node() ::
     #{type => tree_node_type(),
       attrs => map(),
@@ -544,6 +544,10 @@ to_map({generate, Attrs, Pattern, Expr}) ->
     #{type => generate,
       attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
       node_attrs => #{pattern => to_map(Pattern), expression => to_map(Expr)}};
+to_map({generate_strict, Attrs, Pattern, Expr}) ->
+    #{type => generate_strict,
+      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+      node_attrs => #{pattern => to_map(Pattern), expression => to_map(Expr)}};
 to_map({lc_expr, Attrs, Expr}) ->
     #{type => lc_expr,
       attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
@@ -557,6 +561,10 @@ to_map({bc, Attrs, Expr, GeneratorsFilters}) ->
       content => [BcExpr | BcGenerators]};
 to_map({b_generate, Attrs, Pattern, Expr}) ->
     #{type => b_generate,
+      attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
+      node_attrs => #{pattern => to_map(Pattern), expression => to_map(Expr)}};
+to_map({b_generate_strict, Attrs, Pattern, Expr}) ->
+    #{type => b_generate_strict,
       attrs => #{location => get_location(Attrs), text => get_text(Attrs)},
       node_attrs => #{pattern => to_map(Pattern), expression => to_map(Expr)}};
 to_map({bc_expr, Attrs, Expr}) ->

--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -87,28 +87,11 @@
 -elvis([{elvis_style, no_catch_expressions, disable}]).
 -elvis([{elvis_style, no_throw, disable}]).
 -elvis([{elvis_style, consistent_variable_casing, disable}]).
--elvis([{elvis_style, atom_naming_convention, disable}]).
--elvis([{elvis_style, function_naming_convention, disable}]).
 -elvis([{elvis_style, nesting_level, disable}]).
--elvis([{elvis_style, dont_repeat_yourself, disable}]).
 
--export([
-    parse_file/1,
-    quick_parse_file/1,
-    parse_file/2,
-    quick_parse_file/2,
-    parse/1,
-    quick_parse/1,
-    parse/2,
-    quick_parse/2,
-    parse/3,
-    quick_parse/3,
-    parse_form/2,
-    parse_form/3,
-    quick_parse_form/2, quick_parse_form/3,
-    format_error/1,
-    tokens_to_string/1
-]).
+-export([parse_file/1, quick_parse_file/1, parse_file/2, quick_parse_file/2, parse/1,
+         quick_parse/1, parse/2, quick_parse/2, parse/3, quick_parse/3, parse_form/2, parse_form/3,
+         quick_parse_form/2, quick_parse_form/3, format_error/1, tokens_to_string/1]).
 
 %% The following should be: 1) pseudo-uniquely identifiable, and 2)
 %% cause nice looking error messages when the parser has to give up.
@@ -127,9 +110,7 @@
 -hank([{unnecessary_function_arguments, [{no_fix, 1}, {quick_parser, 2}]}]).
 
 %-doc #{equiv => parse_file(File, [])}.
--spec parse_file(file:filename()) ->
-    {'ok', erl_syntax:forms()} | {'error', errorinfo()}.
-
+-spec parse_file(file:filename()) -> {ok, erl_syntax:forms()} | {error, errorinfo()}.
 parse_file(File) ->
     parse_file(File, []).
 
@@ -159,15 +140,13 @@ parse_file(File) ->
 %_See also: _`parse/2`, `quick_parse_file/1`, `erl_syntax:is_form/1`.
 %""".
 -spec parse_file(file:filename(), [option()]) ->
-    {'ok', erl_syntax:forms()} | {'error', errorinfo()}.
-
+                    {ok, erl_syntax:forms()} | {error, errorinfo()}.
 parse_file(File, Options) ->
     parse_file(File, fun parse/3, Options).
 
 %-doc #{equiv => quick_parse_file(File, [])}.
 -spec quick_parse_file(file:filename()) ->
-    {'ok', erl_syntax:forms()} | {'error', errorinfo()}.
-
+                          {ok, erl_syntax:forms()} | {error, errorinfo()}.
 quick_parse_file(File) ->
     quick_parse_file(File, []).
 
@@ -188,8 +167,7 @@ quick_parse_file(File) ->
 %_See also: _`parse_file/2`, `quick_parse/2`.
 %""".
 -spec quick_parse_file(file:filename(), [option()]) ->
-    {'ok', erl_syntax:forms()} | {'error', errorinfo()}.
-
+                          {ok, erl_syntax:forms()} | {error, errorinfo()}.
 quick_parse_file(File, Options) ->
     parse_file(File, fun quick_parse/3, Options ++ [no_fail]).
 
@@ -221,8 +199,7 @@ do_parse_file(DefEncoding, File, Parser, Options) ->
                 ok = file:close(Dev)
             end;
         {error, Error} ->
-            % defer to file:format_error/1
-            {error, {0, file, Error}}
+            {error, {0, file, Error}}  % defer to file:format_error/1
     end.
 
 find_invalid_unicode([H | T]) ->
@@ -238,14 +215,12 @@ find_invalid_unicode([]) ->
 %% =====================================================================
 
 %-doc #{equiv => parse(IODevice, 1)}.
--spec parse(file:io_device()) -> {'ok', erl_syntax:forms()}.
-
+-spec parse(file:io_device()) -> {ok, erl_syntax:forms()}.
 parse(Dev) ->
     parse(Dev, 1).
 
 %-doc #{equiv => parse(IODevice, StartLocation, [])}.
--spec parse(file:io_device(), erl_anno:location()) -> {'ok', erl_syntax:forms()}.
-
+-spec parse(file:io_device(), erl_anno:location()) -> {ok, erl_syntax:forms()}.
 parse(Dev, L) ->
     parse(Dev, L, []).
 
@@ -259,22 +234,17 @@ parse(Dev, L) ->
 %_See also: _`parse/2`, `parse_file/2`, `parse_form/2`, `quick_parse/3`.
 %""".
 -spec parse(file:io_device(), erl_anno:location(), [option()]) ->
-    {'ok', erl_syntax:forms()}.
-
+               {ok, erl_syntax:forms()}.
 parse(Dev, L0, Options) ->
     parse(Dev, L0, fun parse_form/3, Options).
 
 %-doc #{equiv => quick_parse(IODevice, 1)}.
--spec quick_parse(file:io_device()) ->
-    {'ok', erl_syntax:forms()}.
-
+-spec quick_parse(file:io_device()) -> {ok, erl_syntax:forms()}.
 quick_parse(Dev) ->
     quick_parse(Dev, 1).
 
 %-doc #{equiv => quick_parse(IODevice, StartLocation, [])}.
--spec quick_parse(file:io_device(), erl_anno:location()) ->
-    {'ok', erl_syntax:forms()}.
-
+-spec quick_parse(file:io_device(), erl_anno:location()) -> {ok, erl_syntax:forms()}.
 quick_parse(Dev, L) ->
     quick_parse(Dev, L, []).
 
@@ -286,9 +256,7 @@ quick_parse(Dev, L) ->
 %_See also: _`parse/3`, `quick_parse/2`, `quick_parse_file/2`,
 %`quick_parse_form/2`.
 %""".
--spec quick_parse(file:io_device(), erl_anno:location(), [option()]) ->
-    {'ok', erl_syntax:forms()}.
-
+-spec quick_parse(file:io_device(), erl_anno:location(), [option()]) -> {ok, erl_syntax:forms()}.
 quick_parse(Dev, L0, Options) ->
     parse(Dev, L0, fun quick_parse_form/3, Options).
 
@@ -309,10 +277,9 @@ parse(Dev, L0, Fs, Parser, Options) ->
 
 %-doc #{equiv => parse_form(IODevice, StartLocation, [])}.
 -spec parse_form(file:io_device(), erl_anno:location()) ->
-    {'ok', erl_syntax:forms(), erl_anno:location()}
-    | {'eof', erl_anno:location()}
-    | {'error', errorinfo(), erl_anno:location()}.
-
+                    {ok, erl_syntax:forms(), erl_anno:location()} |
+                    {eof, erl_anno:location()} |
+                    {error, errorinfo(), erl_anno:location()}.
 parse_form(Dev, L0) ->
     parse_form(Dev, L0, []).
 
@@ -329,19 +296,17 @@ parse_form(Dev, L0) ->
 %_See also: _`parse/3`, `parse_form/2`, `quick_parse_form/3`.
 %""".
 -spec parse_form(file:io_device(), erl_anno:location(), [option()]) ->
-    {'ok', erl_syntax:forms(), erl_anno:location()}
-    | {'eof', erl_anno:location()}
-    | {'error', errorinfo(), erl_anno:location()}.
-
+                    {ok, erl_syntax:forms(), erl_anno:location()} |
+                    {eof, erl_anno:location()} |
+                    {error, errorinfo(), erl_anno:location()}.
 parse_form(Dev, L0, Options) ->
     parse_form(Dev, L0, fun normal_parser/2, Options).
 
 %-doc #{equiv => quick_parse_form(IODevice, StartLocation, [])}.
 -spec quick_parse_form(file:io_device(), erl_anno:location()) ->
-    {'ok', erl_syntax:forms(), erl_anno:location()}
-    | {'eof', erl_anno:location()}
-    | {'error', errorinfo(), erl_anno:location()}.
-
+                          {ok, erl_syntax:forms(), erl_anno:location()} |
+                          {eof, erl_anno:location()} |
+                          {error, errorinfo(), erl_anno:location()}.
 quick_parse_form(Dev, L0) ->
     quick_parse_form(Dev, L0, []).
 
@@ -352,10 +317,9 @@ quick_parse_form(Dev, L0) ->
 %_See also: _`parse/3`, `parse_form/3`, `quick_parse_form/2`.
 %""".
 -spec quick_parse_form(file:io_device(), erl_anno:location(), [option()]) ->
-    {'ok', erl_syntax:forms(), erl_anno:location()}
-    | {'eof', erl_anno:location()}
-    | {'error', errorinfo(), erl_anno:location()}.
-
+                          {ok, erl_syntax:forms(), erl_anno:location()} |
+                          {eof, erl_anno:location()} |
+                          {error, errorinfo(), erl_anno:location()}.
 quick_parse_form(Dev, L0, Options) ->
     parse_form(Dev, L0, fun quick_parser/2, Options).
 
@@ -363,23 +327,20 @@ quick_parse_form(Dev, L0, Options) ->
 -type post_fixer() ::
     fun((erl_parse:abstract_form()) -> no_fix | {form, erl_parse:abstract_form()}).
 
--record(opt, {
-    clever = false :: boolean(),
-    parse_macro_definitions = false :: boolean(),
-    compact_strings = false :: boolean(),
-    pre_fixer = fun no_fix/1 :: pre_fixer(),
-    post_fixer = fun no_fix/1 :: post_fixer()
-}).
+-record(opt,
+        {clever = false :: boolean(),
+         parse_macro_definitions = false :: boolean(),
+         compact_strings = false :: boolean(),
+         pre_fixer = fun no_fix/1 :: pre_fixer(),
+         post_fixer = fun no_fix/1 :: post_fixer()}).
 
 parse_form(Dev, L0, Parser, Options) ->
     NoFail = proplists:get_bool(no_fail, Options),
-    Opt = #opt{
-        clever = proplists:get_bool(clever, Options),
-        parse_macro_definitions = proplists:get_bool(parse_macro_definitions, Options),
-        compact_strings = proplists:get_bool(compact_strings, Options),
-        pre_fixer = proplists:get_value(pre_fixer, Options, fun no_fix/1),
-        post_fixer = proplists:get_value(post_fixer, Options, fun no_fix/1)
-    },
+    Opt = #opt{clever = proplists:get_bool(clever, Options),
+               parse_macro_definitions = proplists:get_bool(parse_macro_definitions, Options),
+               compact_strings = proplists:get_bool(compact_strings, Options),
+               pre_fixer = proplists:get_value(pre_fixer, Options, fun no_fix/1),
+               post_fixer = proplists:get_value(post_fixer, Options, fun no_fix/1)},
 
     %% This has the *potential* to read options for enabling/disabling
     %% (i.e. `{feature, TheFeature, enable}') when parsing the file.
@@ -395,13 +356,11 @@ parse_form(Dev, L0, Parser, Options) ->
                     case parse_form(Parser, Rest, L1, NoFail, Opt) of
                         {ok, Form, L2} ->
                             {ok,
-                                erl_syntax:form_list([
-                                    erl_syntax:set_pos(
-                                        erl_syntax:text(tokens_to_string(Header)),
-                                        LineNo
-                                    ),
-                                    Form
-                                ]), L2};
+                             erl_syntax:form_list([erl_syntax:set_pos(
+                                                       erl_syntax:text(tokens_to_string(Header)),
+                                                       LineNo),
+                                                   Form]),
+                             L2};
                         Error ->
                             Error
                     end
@@ -409,8 +368,7 @@ parse_form(Dev, L0, Parser, Options) ->
         {error, _IoErr, _L1} = Err ->
             Err;
         {error, _Reason} ->
-            % This is probably encoding problem
-            {eof, L0};
+            {eof, L0}; % This is probably encoding problem
         {eof, _L1} = Eof ->
             Eof
     end.
@@ -430,11 +388,10 @@ parse_form(Parser, Ts, L1, NoFail, Opt) ->
             {error, IoErr, L1};
         {parse_error, _IoErr} when NoFail ->
             {ok,
-                erl_syntax:set_pos(
-                    erl_syntax:text(tokens_to_string(Ts)),
-                    erl_anno:new(start_pos(Ts, L1))
-                ),
-                L1};
+             erl_syntax:set_pos(
+                 erl_syntax:text(tokens_to_string(Ts)),
+                 erl_anno:new(start_pos(Ts, L1))),
+             L1};
         {parse_error, IoErr} ->
             {error, IoErr, L1};
         {ok, F} ->
@@ -515,8 +472,7 @@ parse_tokens_as_terms(Ts, PreFix, FormFix) ->
 
 expression_dot() ->
     erl_syntax:set_ann(
-        erl_syntax:text("."), [expression_dot]
-    ).
+        erl_syntax:text("."), [expression_dot]).
 
 %% ---------------------------------------------------------------------
 %% Quick scanning/parsing - deletes macro definitions and other
@@ -549,75 +505,60 @@ quickscan_form([{'-', _Anno}, {atom, AnnoA, endif} | _Ts]) ->
     kill_form(AnnoA);
 quickscan_form([{'-', _Anno}, {atom, AnnoA, feature} | _Ts]) ->
     kill_form(AnnoA);
-quickscan_form([{'-', Anno}, {'?', _}, {Type, _, _} = N | [{'(', _} | _] = Ts]) when
-    Type =:= atom; Type =:= var
-->
+quickscan_form([{'-', Anno}, {'?', _}, {Type, _, _} = N | [{'(', _} | _] = Ts])
+    when Type =:= atom; Type =:= var ->
     %% minus, macro and open parenthesis at start of form - assume that
     %% the macro takes no arguments; e.g. `-?foo(...).'
-    quickscan_macros_1(N, Ts, [{'-', Anno}]);
-quickscan_form([{'?', _Anno}, {Type, _, _} = N | [{'(', _} | _] = Ts]) when
-    Type =:= atom; Type =:= var
-->
+    do_quickscan_macros(N, Ts, [{'-', Anno}]);
+quickscan_form([{'?', _Anno}, {Type, _, _} = N | [{'(', _} | _] = Ts])
+    when Type =:= atom; Type =:= var ->
     %% macro and open parenthesis at start of form - assume that the
     %% macro takes no arguments (see scan_macros for details)
-    quickscan_macros_1(N, Ts, []);
+    do_quickscan_macros(N, Ts, []);
 quickscan_form(Ts) ->
     quickscan_macros(Ts).
 
 kill_form(A) ->
-    [
-        {atom, A, ?pp_form},
-        {'(', A},
-        {')', A},
-        {'->', A},
-        {atom, A, kill},
-        {dot, A}
-    ].
+    [{atom, A, ?pp_form}, {'(', A}, {')', A}, {'->', A}, {atom, A, kill}, {dot, A}].
 
 quickscan_macros(Ts) ->
     quickscan_macros(Ts, []).
 
-quickscan_macros([{'?', _}, {Type, _, A} | Ts], [{string, AnnoS, S} | As]) when
-    Type =:= atom; Type =:= var
-->
+quickscan_macros([{'?', _}, {Type, _, A} | Ts], [{string, AnnoS, S} | As])
+  when Type =:= atom; Type =:= var ->
     %% macro after a string literal: change to a single string
     {_, Ts1} = skip_macro_args(Ts),
     S1 = S ++ quick_macro_string(A),
     quickscan_macros(Ts1, [{string, AnnoS, S1} | As]);
-quickscan_macros(
-    [{'?', _}, {Type, _, _} = N | [{'(', _} | _] = Ts],
-    [{':', _} | _] = As
-) when
-    Type =:= atom; Type =:= var
-->
+quickscan_macros([{'?', _}, {Type, _, _} = N | [{'(', _} | _] = Ts], [{':', _} | _] = As)
+    when Type =:= atom; Type =:= var ->
     %% macro and open parenthesis after colon - check the token
     %% following the arguments (see scan_macros for details)
-    Ts1 =
-        case skip_macro_args(Ts) of
-            {_, [{'->', _} | _] = Ts2} -> Ts2;
-            {_, [{'when', _} | _] = Ts2} -> Ts2;
-            {_, [{':', _} | _] = Ts2} -> Ts2;
-            %% assume macro without arguments
-            _ -> Ts
-        end,
-    quickscan_macros_1(N, Ts1, As);
-quickscan_macros([{'?', _}, {Type, _, _} = N | Ts], As) when
-    Type =:= atom; Type =:= var
-->
+    Ts1 = case skip_macro_args(Ts) of
+              {_, [{'->', _} | _] = Ts2} ->
+                  Ts2;
+              {_, [{'when', _} | _] = Ts2} ->
+                  Ts2;
+              _ ->
+                  Ts    %% assume macro without arguments
+          end,
+    do_quickscan_macros(N, Ts1, As);
+quickscan_macros([{'?', _}, {Type, _, _} = N | Ts], As)
+    when Type =:= atom; Type =:= var ->
     %% macro with or without arguments
     {_, Ts1} = skip_macro_args(Ts),
-    quickscan_macros_1(N, Ts1, As);
+    do_quickscan_macros(N, Ts1, As);
 quickscan_macros([T | Ts], As) ->
     quickscan_macros(Ts, [T | As]);
 quickscan_macros([], As) ->
     lists:reverse(As).
 
 %% (after a macro has been found and the arglist skipped, if any)
-quickscan_macros_1({_Type, _, A}, [{string, AnnoS, S} | Ts], As) ->
+do_quickscan_macros({_Type, _, A}, [{string, AnnoS, S} | Ts], As) ->
     %% string literal following macro: change to single string
     S1 = quick_macro_string(A) ++ S,
     quickscan_macros(Ts, [{string, AnnoS, S1} | As]);
-quickscan_macros_1({_Type, AnnoA, A}, Ts, As) ->
+do_quickscan_macros({_Type, AnnoA, A}, Ts, As) ->
     %% normal case - just replace the macro with an atom
     quickscan_macros(Ts, [{atom, AnnoA, quick_macro_atom(A)} | As]).
 
@@ -654,11 +595,9 @@ skip_macro_args([{'receive', _} = T | Ts], Es, As) ->
     skip_macro_args(Ts, ['end' | Es], [T | As]);
 skip_macro_args([{'try', _} = T | Ts], Es, As) ->
     skip_macro_args(Ts, ['end' | Es], [T | As]);
-%final close
-skip_macro_args([{E, _} = T | Ts], [E], As) ->
+skip_macro_args([{E, _} = T | Ts], [E], As) -> %final close
     {lists:reverse([T | As]), Ts};
-%matching close
-skip_macro_args([{E, _} = T | Ts], [E | Es], As) ->
+skip_macro_args([{E, _} = T | Ts], [E | Es], As) -> %matching close
     skip_macro_args(Ts, Es, [T | As]);
 skip_macro_args([T | Ts], Es, As) ->
     skip_macro_args(Ts, Es, [T | As]);
@@ -670,20 +609,17 @@ filter_form({function, _, ?pp_form, _, [{clause, _, [], [], [{atom, _, kill}]}]}
 filter_form(T) ->
     T.
 
+
 %% ---------------------------------------------------------------------
 %% Normal parsing - try to preserve all information
 
 normal_parser(Ts0, Opt) ->
     case scan_form(Ts0, Opt) of
         Ts when is_list(Ts) ->
-            rewrite_form(
-                parse_tokens(
-                    Ts,
-                    normal_parser_prefix(Opt),
-                    fun fix_form/1,
-                    Opt#opt.post_fixer
-                )
-            );
+            rewrite_form(parse_tokens(Ts,
+                                      normal_parser_prefix(Opt),
+                                      fun fix_form/1,
+                                      Opt#opt.post_fixer));
         Node ->
             Node
     end.
@@ -691,17 +627,17 @@ normal_parser(Ts0, Opt) ->
 normal_parser_prefix(#opt{pre_fixer = PreFixer} = Opt) ->
     DefaultPrefix = default_prefix(Opt),
     fun(Ts) ->
-        case PreFixer(Ts) of
-            no_fix ->
-                DefaultPrefix(Ts);
-            {retry, Ts1} ->
-                case DefaultPrefix(Ts1) of
-                    no_fix ->
-                        {retry, Ts1};
-                    Other ->
-                        Other
-                end
-        end
+       case PreFixer(Ts) of
+           no_fix ->
+               DefaultPrefix(Ts);
+           {retry, Ts1} ->
+               case DefaultPrefix(Ts1) of
+                   no_fix ->
+                       {retry, Ts1};
+                   Other ->
+                       Other
+               end
+       end
     end.
 
 default_prefix(#opt{parse_macro_definitions = true, compact_strings = false}) ->
@@ -712,118 +648,60 @@ default_prefix(#opt{parse_macro_definitions = false, compact_strings = false}) -
     fun fix_define/1;
 default_prefix(#opt{parse_macro_definitions = false, compact_strings = true}) ->
     fun(Ts) ->
-        case fix_contiguous_strings(Ts) of
-            no_fix ->
-                fix_define(Ts);
-            {retry, Ts1} ->
-                case fix_define(Ts1) of
-                    no_fix ->
-                        {retry, Ts1};
-                    Other ->
-                        Other
-                end
-        end
+       case fix_contiguous_strings(Ts) of
+           no_fix ->
+               fix_define(Ts);
+           {retry, Ts1} ->
+               case fix_define(Ts1) of
+                   no_fix ->
+                       {retry, Ts1};
+                   Other ->
+                       Other
+               end
+       end
     end.
 
-scan_form([{'-', _Anno}, {atom, AnnoA, define} | Ts], Opt) ->
+scan_form([{'-', _Anno}, {atom, AnnoA, define} | Ts], #opt{parse_macro_definitions = false}) ->
     [
         {atom, AnnoA, ?pp_form},
         {'(', AnnoA},
         {')', AnnoA},
         {'->', AnnoA},
         {atom, AnnoA, define}
-        | scan_macros(Ts, Opt)
-    ];
+    | Ts];
+scan_form([{'-', _Anno}, {atom, AnnoA, define} | Ts], Opt) ->
+    [{atom, AnnoA, ?pp_form}, {'(', AnnoA}, {')', AnnoA}, {'->', AnnoA}, {atom, AnnoA, define}
+     | scan_macros(Ts, Opt)];
 scan_form([{'-', _Anno}, {atom, AnnoA, undef} | Ts], Opt) ->
-    [
-        {atom, AnnoA, ?pp_form},
-        {'(', AnnoA},
-        {')', AnnoA},
-        {'->', AnnoA},
-        {atom, AnnoA, undef}
-        | scan_macros(Ts, Opt)
-    ];
+    [{atom, AnnoA, ?pp_form}, {'(', AnnoA}, {')', AnnoA}, {'->', AnnoA}, {atom, AnnoA, undef}
+     | scan_macros(Ts, Opt)];
 scan_form([{'-', _Anno}, {atom, AnnoA, include} | Ts], Opt) ->
-    [
-        {atom, AnnoA, ?pp_form},
-        {'(', AnnoA},
-        {')', AnnoA},
-        {'->', AnnoA},
-        {atom, AnnoA, include}
-        | scan_macros(Ts, Opt)
-    ];
+    [{atom, AnnoA, ?pp_form}, {'(', AnnoA}, {')', AnnoA}, {'->', AnnoA}, {atom, AnnoA, include}
+     | scan_macros(Ts, Opt)];
 scan_form([{'-', _Anno}, {atom, AnnoA, include_lib} | Ts], Opt) ->
-    [
-        {atom, AnnoA, ?pp_form},
-        {'(', AnnoA},
-        {')', AnnoA},
-        {'->', AnnoA},
-        {atom, AnnoA, include_lib}
-        | scan_macros(Ts, Opt)
-    ];
+    [{atom, AnnoA, ?pp_form}, {'(', AnnoA}, {')', AnnoA}, {'->', AnnoA}, {atom, AnnoA, include_lib}
+     | scan_macros(Ts, Opt)];
 scan_form([{'-', _Anno}, {atom, AnnoA, ifdef} | Ts], Opt) ->
-    [
-        {atom, AnnoA, ?pp_form},
-        {'(', AnnoA},
-        {')', AnnoA},
-        {'->', AnnoA},
-        {atom, AnnoA, ifdef}
-        | scan_macros(Ts, Opt)
-    ];
+    [{atom, AnnoA, ?pp_form}, {'(', AnnoA}, {')', AnnoA}, {'->', AnnoA}, {atom, AnnoA, ifdef}
+     | scan_macros(Ts, Opt)];
 scan_form([{'-', _Anno}, {atom, AnnoA, ifndef} | Ts], Opt) ->
-    [
-        {atom, AnnoA, ?pp_form},
-        {'(', AnnoA},
-        {')', AnnoA},
-        {'->', AnnoA},
-        {atom, AnnoA, ifndef}
-        | scan_macros(Ts, Opt)
-    ];
+    [{atom, AnnoA, ?pp_form}, {'(', AnnoA}, {')', AnnoA}, {'->', AnnoA}, {atom, AnnoA, ifndef}
+     | scan_macros(Ts, Opt)];
 scan_form([{'-', _Anno}, {'if', AnnoA} | Ts], Opt) ->
-    [
-        {atom, AnnoA, ?pp_form},
-        {'(', AnnoA},
-        {')', AnnoA},
-        {'->', AnnoA},
-        {atom, AnnoA, 'if'}
-        | scan_macros(Ts, Opt)
-    ];
+    [{atom, AnnoA, ?pp_form}, {'(', AnnoA}, {')', AnnoA}, {'->', AnnoA}, {atom, AnnoA, 'if'}
+     | scan_macros(Ts, Opt)];
 scan_form([{'-', _Anno}, {atom, AnnoA, elif} | Ts], Opt) ->
-    [
-        {atom, AnnoA, ?pp_form},
-        {'(', AnnoA},
-        {')', AnnoA},
-        {'->', AnnoA},
-        {atom, AnnoA, 'elif'}
-        | scan_macros(Ts, Opt)
-    ];
+    [{atom, AnnoA, ?pp_form}, {'(', AnnoA}, {')', AnnoA}, {'->', AnnoA}, {atom, AnnoA, elif}
+     | scan_macros(Ts, Opt)];
 scan_form([{'-', _Anno}, {atom, AnnoA, 'else'} | Ts], Opt) ->
-    [
-        {atom, AnnoA, ?pp_form},
-        {'(', AnnoA},
-        {')', AnnoA},
-        {'->', AnnoA},
-        {atom, AnnoA, 'else'}
-        | scan_macros(Ts, Opt)
-    ];
-scan_form([{'-', _Anno}, {'else', AnnoA} | Ts], Opt) ->
-    [
-        {atom, AnnoA, ?pp_form},
-        {'(', AnnoA},
-        {')', AnnoA},
-        {'->', AnnoA},
-        {atom, AnnoA, 'else'}
-        | scan_macros(Ts, Opt)
-    ];
+    [{atom, AnnoA, ?pp_form}, {'(', AnnoA}, {')', AnnoA}, {'->', AnnoA}, {atom, AnnoA, 'else'}
+     | scan_macros(Ts, Opt)];
+scan_form([{'-', Anno}, {'else', AnnoA} | Ts], Opt) ->
+    %% See previous clause
+    scan_form([{'-', Anno}, {atom, AnnoA, 'else'} | Ts], Opt);
 scan_form([{'-', _Anno}, {atom, AnnoA, endif} | Ts], Opt) ->
-    [
-        {atom, AnnoA, ?pp_form},
-        {'(', AnnoA},
-        {')', AnnoA},
-        {'->', AnnoA},
-        {atom, AnnoA, endif}
-        | scan_macros(Ts, Opt)
-    ];
+    [{atom, AnnoA, ?pp_form}, {'(', AnnoA}, {')', AnnoA}, {'->', AnnoA}, {atom, AnnoA, endif}
+     | scan_macros(Ts, Opt)];
 scan_form([{'-', _Anno}, {atom, AnnoA, error} | Ts], _Opt) ->
     Desc = build_info_string("-error", Ts),
     ErrorInfo = {erl_anno:location(AnnoA), ?MODULE, {error, Desc}},
@@ -832,15 +710,13 @@ scan_form([{'-', _Anno}, {atom, AnnoA, warning} | Ts], _Opt) ->
     Desc = build_info_string("-warning", Ts),
     ErrorInfo = {erl_anno:location(AnnoA), ?MODULE, {warning, Desc}},
     erl_syntax:error_marker(ErrorInfo);
-scan_form([{'-', A}, {'?', A1}, {Type, _, _} = N | [{'(', _} | _] = Ts], Opt) when
-    Type =:= atom; Type =:= var
-->
+scan_form([{'-', A}, {'?', A1}, {Type, _, _} = N | [{'(', _} | _] = Ts], Opt)
+    when Type =:= atom; Type =:= var ->
     %% minus, macro and open parenthesis at start of form - assume that
     %% the macro takes no arguments; e.g. `-?foo(...).'
     macro(A1, N, Ts, [{'-', A}], Opt);
-scan_form([{'?', A}, {Type, _, _} = N | [{'(', _} | _] = Ts], Opt) when
-    Type =:= atom; Type =:= var
-->
+scan_form([{'?', A}, {Type, _, _} = N | [{'(', _} | _] = Ts], Opt)
+    when Type =:= atom; Type =:= var ->
     %% macro and open parenthesis at start of form - assume that the
     %% macro takes no arguments; probably a function declaration on the
     %% form `?m(...) -> ...', which will not parse if it is rewritten as
@@ -857,22 +733,14 @@ build_info_string(Prefix, Ts0) ->
 scan_macros(Ts, Opt) ->
     scan_macros(Ts, [], Opt).
 
-scan_macros(
-    [{'?', _} = M, {Type, _, _} = N | Ts],
-    [{string, AnnoS, _} = S | As],
-    #opt{clever = true} = Opt
-) when
-    Type =:= atom; Type =:= var
-->
+scan_macros([{'?', _} = M, {Type, _, _} = N | Ts],
+            [{string, AnnoS, _} = S | As],
+            #opt{clever = true} = Opt)
+    when Type =:= atom; Type =:= var ->
     %% macro after a string literal: be clever and insert ++
     scan_macros([M, N | Ts], [{'++', AnnoS}, S | As], Opt);
-scan_macros(
-    [{'?', Anno}, {Type, _, _} = N | [{'(', _} | _] = Ts],
-    [{':', _} | _] = As,
-    Opt
-) when
-    Type =:= atom; Type =:= var
-->
+scan_macros([{'?', Anno}, {Type, _, _} = N | [{'(', _} | _] = Ts], [{':', _} | _] = As, Opt)
+    when Type =:= atom; Type =:= var ->
     %% macro and open parentheses after colon - probably a call
     %% `m:?F(...)' so the argument list might belong to the call, not
     %% the macro - but it could also be a try-clause pattern
@@ -889,15 +757,13 @@ scan_macros(
         _ ->
             macro(Anno, N, Ts, As, Opt)
     end;
-scan_macros([{'?', Anno}, {Type, _, _} = N | [{'(', _} | _] = Ts], As, Opt) when
-    Type =:= atom; Type =:= var
-->
+scan_macros([{'?', Anno}, {Type, _, _} = N | [{'(', _} | _] = Ts], As, Opt)
+    when Type =:= atom; Type =:= var ->
     %% macro with arguments
     {Args, Rest} = skip_macro_args(Ts),
     macro_call(Args, Anno, N, Rest, As, Opt);
-scan_macros([{'?', Anno}, {Type, _, _} = N | Ts], As, Opt) when
-    Type =:= atom; Type =:= var
-->
+scan_macros([{'?', Anno}, {Type, _, _} = N | Ts], As, Opt)
+    when Type =:= atom; Type =:= var ->
     %% macro without arguments
     macro(Anno, N, Ts, As, Opt);
 scan_macros([T | Ts], As, Opt) ->
@@ -909,28 +775,19 @@ scan_macros([], As, _Opt) ->
 %% (we insert parentheses to preserve the precedences when parsing).
 
 macro(Anno, {Type, _, A}, Rest, As, Opt) ->
-    scan_macros_1([], Rest, [{atom, Anno, macro_atom(Type, A)} | As], Opt).
+    do_scan_macros([], Rest, [{atom, Anno, macro_atom(Type, A)} | As], Opt).
 
 macro_call([{'(', _}, {')', _}], Anno, {_, AnnoN, _} = N, Rest, As, Opt) ->
     {Open, Close} = parentheses(As),
-    scan_macros_1(
-        [],
-        Rest,
-        %% {'?macro_call', N }
-        lists:reverse(
-            Open ++
-                [
-                    {'{', Anno},
-                    {atom, Anno, ?macro_call},
-                    {',', Anno},
-                    N,
-                    {'}', AnnoN}
-                ] ++ Close,
-            As
-        ),
-        Opt
-    );
-macro_call([{'(', _} | Args], Anno, {_, AnnoN, _} = N, Rest, As, Opt) ->
+    do_scan_macros([],
+                  Rest,
+                  lists:reverse(
+                    Open ++
+                    [{atom, Anno, ?macro_call}, {'(', Anno}, N, {')', AnnoN}] ++
+                    Close,
+                    As),
+                  Opt);
+macro_call([{'(', _} | Args], L, {_, Ln, _} = N, Rest, As, Opt) ->
     {Open, Close} = parentheses(As),
     %% drop closing parenthesis
 
@@ -938,23 +795,10 @@ macro_call([{'(', _} | Args], Anno, {_, AnnoN, _} = N, Rest, As, Opt) ->
     {')', _} = lists:last(Args),
     Args1 = lists:droplast(Args),
     %% note that we must scan the argument list; it may not be skipped
-    scan_macros_1(
-        Args1 ++ [{'}', AnnoN} | Close],
-        Rest,
-        %% {'?macro_call', N, Arg1, ... }
-        lists:reverse(
-            Open ++
-                [
-                    {'{', Anno},
-                    {atom, Anno, ?macro_call},
-                    {',', Anno},
-                    N,
-                    {',', AnnoN}
-                ],
-            As
-        ),
-        Opt
-    ).
+    do_scan_macros(Args1 ++ [{'}', Ln} | Close],
+                  Rest,
+                  lists:reverse(Open ++ [{atom, L, ?macro_call}, {'(', L}, N, {',', Ln}], As),
+                  Opt).
 
 macro_atom(atom, A) ->
     list_to_atom(?atom_prefix ++ atom_to_list(A));
@@ -970,22 +814,19 @@ parentheses(_) ->
     {[{'(', 0}], [{')', 0}]}.
 
 %% (after a macro has been found and the arglist skipped, if any)
-scan_macros_1(
-    Args,
-    [{string, AnnoS, _} | _] = Rest,
-    As,
-    #opt{clever = true} = Opt
-) ->
+do_scan_macros(Args, [{string, AnnoS, _} | _] = Rest, As, #opt{clever = true} = Opt) ->
     %% string literal following macro: be clever and insert ++
-    scan_macros(Args ++ [{'++', AnnoS} | Rest], As, Opt);
-scan_macros_1(Args, Rest, As, Opt) ->
+    scan_macros(Args ++ [{'++', AnnoS} | Rest],  As, Opt);
+do_scan_macros(Args, Rest, As, Opt) ->
     %% normal case - continue scanning
     scan_macros(Args ++ Rest, As, Opt).
 
 rewrite_form({function, Anno, ?pp_form, _, [{clause, _, [], [], [{call, _, A, As}]}]}) ->
-    erl_syntax:set_pos(erl_syntax:attribute(A, rewrite_list(As)), Anno);
+    erl_syntax:set_pos(
+        erl_syntax:attribute(A, rewrite_list(As)), Anno);
 rewrite_form({function, Anno, ?pp_form, _, [{clause, _, [], [], [A]}]}) ->
-    erl_syntax:set_pos(erl_syntax:attribute(A), Anno);
+    erl_syntax:set_pos(
+        erl_syntax:attribute(A), Anno);
 rewrite_form(T) ->
     rewrite(T).
 
@@ -1024,10 +865,10 @@ rewrite(Node) ->
                             M = erl_syntax:macro(A, rewrite_list(As)),
                             erl_syntax:copy_pos(Node, M);
                         _ ->
-                            rewrite_1(Node)
+                            do_rewrite(Node)
                     end;
                 _ ->
-                    rewrite_1(Node)
+                    do_rewrite(Node)
             end;
         tuple ->
             case erl_syntax:tuple_elements(Node) of
@@ -1039,47 +880,35 @@ rewrite(Node) ->
                                     M = erl_syntax:macro(A, rewrite_list(As)),
                                     erl_syntax:copy_pos(Node, M);
                                 _ ->
-                                    rewrite_1(Node)
+                                    do_rewrite(Node)
                             end;
                         _ ->
-                            rewrite_1(Node)
+                            do_rewrite(Node)
                     end;
                 _ ->
-                    rewrite_1(Node)
+                    do_rewrite(Node)
             end;
         _ ->
-            rewrite_1(Node)
+            do_rewrite(Node)
     end.
 
-rewrite_1(Node) ->
+do_rewrite(Node) ->
     case erl_syntax:subtrees(Node) of
         [] ->
             Node;
         Gs ->
-            Node1 = erl_syntax:make_tree(
-                erl_syntax:type(Node),
-                [
-                    [rewrite(T) || T <- Ts]
-                 || Ts <- Gs
-                ]
-            ),
+            Node1 =
+                erl_syntax:make_tree(
+                    erl_syntax:type(Node), [[rewrite(T) || T <- Ts] || Ts <- Gs]),
             erl_syntax:copy_pos(Node, Node1)
     end.
 
 %% attempting a rescue operation on a token sequence for a single form
 %% if it could not be parsed after the normal treatment
 
-fix_form(
-    [
-        {atom, _, ?pp_form},
-        {'(', _},
-        {')', _},
-        {'->', _},
-        {atom, _, define},
-        {'(', _}
-        | _
-    ] = Ts
-) ->
+fix_form([{atom, _, ?pp_form}, {'(', _}, {')', _}, {'->', _}, {atom, _, define}, {'(', _}
+          | _] =
+             Ts) ->
     case lists:reverse(Ts) of
         [{dot, _}, {')', _} | _] ->
             {retry, Ts, fun fix_stringyfied_macros/1};
@@ -1109,22 +938,24 @@ fix_stringyfied_macros([{'?', Pos}, {atom, Pos, MacroName} | Rest], Ts) ->
 fix_stringyfied_macros([Other | Rest], Ts) ->
     fix_stringyfied_macros(Rest, [Other | Ts]).
 
-fix_define([
-    {atom, Anno, ?pp_form},
-    {'(', _},
-    {')', _},
-    {'->', _},
-    {atom, AnnoA, define},
-    {'(', _},
-    N,
-    {',', _}
-    | Ts
-]) ->
+fix_define([{atom, Anno, ?pp_form},
+            {'(', _},
+            {')', _},
+            {'->', _},
+            {atom, AnnoA, define},
+            {'(', _},
+            N,
+            {',', _}
+            | Ts]) ->
     [{dot, _}, {')', _} | Ts1] = lists:reverse(Ts),
     S = tokens_to_string(lists:reverse(Ts1)),
-    A = erl_syntax:set_pos(erl_syntax:atom(define), AnnoA),
-    Txt = erl_syntax:set_pos(erl_syntax:text(S), AnnoA),
-    {form, erl_syntax:set_pos(erl_syntax:attribute(A, [N, Txt]), Anno)};
+    A = erl_syntax:set_pos(
+            erl_syntax:atom(define), AnnoA),
+    Txt = erl_syntax:set_pos(
+              erl_syntax:text(S), AnnoA),
+    {form,
+     erl_syntax:set_pos(
+         erl_syntax:attribute(A, [N, Txt]), Anno)};
 fix_define(_Ts) ->
     no_fix.
 
@@ -1138,10 +969,8 @@ fix_contiguous_strings(Ts) ->
 
 fix_contiguous_strings([], Ts) ->
     lists:reverse(Ts);
-fix_contiguous_strings(
-    [{string, L1, S1} = First, {string, L2, S2} = Second | Rest],
-    Ts
-) ->
+fix_contiguous_strings([{string, L1, S1} = First, {string, L2, S2} = Second | Rest],
+                       Ts) ->
     case {erl_anno:text(L1), erl_anno:text(L2)} of
         {T1, T2} when is_list(T1), is_list(T2) ->
             Separator =
@@ -1149,8 +978,7 @@ fix_contiguous_strings(
                     {L, L} ->
                         $\s;
                     {_, _} ->
-                        % different lines
-                        $\n
+                        $\n % different lines
                 end,
             NewL = erl_anno:set_text(T1 ++ [Separator | T2], L1),
             fix_contiguous_strings([{string, NewL, S1 ++ S2} | Rest], Ts);
@@ -1168,32 +996,78 @@ no_fix(_) ->
 %
 %The string can be re-tokenized to yield the same token list again.
 %""".
--spec tokens_to_string([term()]) -> string().
+token_to_string(T) ->
+    case erl_scan:text(T) of
+        undefined ->
+            token_to_string(erl_scan:category(T), erl_scan:symbol(T));
+        Text ->
+            Text
+    end.
 
-tokens_to_string([{atom, _, A} | Ts]) ->
-    io_lib:write_atom(A) ++ " " ++ tokens_to_string(Ts);
-tokens_to_string([{string, _, S} | Ts]) ->
-    io_lib:write_string(S) ++ " " ++ tokens_to_string(Ts);
-tokens_to_string([{char, _, C} | Ts]) ->
-    io_lib:write_char(C) ++ " " ++ tokens_to_string(Ts);
-tokens_to_string([{float, _, F} | Ts]) ->
-    float_to_list(F) ++ " " ++ tokens_to_string(Ts);
-tokens_to_string([{integer, _, N} | Ts]) ->
-    integer_to_list(N) ++ " " ++ tokens_to_string(Ts);
-tokens_to_string([{var, _, A} | Ts]) ->
-    atom_to_list(A) ++ " " ++ tokens_to_string(Ts);
-tokens_to_string([{dot, _} | Ts]) ->
-    ".\n" ++ tokens_to_string(Ts);
+token_to_string(atom, A) ->
+    io_lib:write_atom(A);
+token_to_string(string, S) ->
+    io_lib:write_string(S);
+token_to_string(char, C) ->
+    io_lib:write_char(C);
+token_to_string(float, F) ->
+    lists:flatten(
+        io_lib:format("~p", [F]));
+token_to_string(integer, N) ->
+    lists:flatten(
+        io_lib:format("~p", [N]));
+token_to_string(var, A) ->
+    atom_to_list(A);
+token_to_string(dot, dot) ->
+    ".\n";
 % from OTP: -type af_sigil_prefix() :: {'sigil_prefix', anno(), atom()}.
-tokens_to_string([{sigil_prefix, _, _Prefix} | Ts]) ->
-    "" ++ tokens_to_string(Ts);
+token_to_string(sigil_prefix, _Prefix) ->
+    "";
 % from OTP: -type af_sigil_suffix() :: {'sigil_suffix', anno(), string()}.
-tokens_to_string([{sigil_suffix, _, _Suffix} | Ts]) ->
-    "" ++ tokens_to_string(Ts);
-tokens_to_string([{A, _} | Ts]) ->
-    atom_to_list(A) ++ " " ++ tokens_to_string(Ts);
+token_to_string(sigil_suffix, _Suffix) ->
+    "";
+token_to_string(Same, Same) ->
+    atom_to_list(Same).
+
+-spec tokens_to_string([term()]) -> string().
+tokens_to_string([T | Ts]) ->
+    token_to_string(T) ++ maybe_space(erl_scan:category(T), Ts) ++ tokens_to_string(Ts);
 tokens_to_string([]) ->
     "".
+
+maybe_space(_, []) ->
+    "";
+maybe_space(C, [T | _]) ->
+    maybe_space_between(C, erl_scan:category(T)).
+
+maybe_space_between(dot, _) ->
+    ""; % No space at the end
+maybe_space_between('#', '!') ->
+    ""; %  \
+maybe_space_between('!', '/') ->
+    ""; %   \_ No space for escript headers
+maybe_space_between('/', atom) ->
+    ""; %  /
+maybe_space_between(atom, '/') ->
+    ""; % /
+maybe_space_between('#', _) ->
+    ""; % No space for records and maps
+maybe_space_between(atom, '{') ->
+    ""; % No space for records
+maybe_space_between('?', _) ->
+    ""; % No space for macro names
+maybe_space_between('-', atom) ->
+    ""; % No space for attributes
+maybe_space_between(atom, '(') ->
+    ""; % No space for function calls
+maybe_space_between(var, '(') ->
+    ""; % No space for function calls
+maybe_space_between(_, _) ->
+    " ". % Space between anything else
+
+%% @private
+%% @doc Callback function for formatting error descriptors. Not for
+%% normal use.
 
 %-doc false.
 -spec format_error(term()) -> string().
@@ -1209,6 +1083,7 @@ format_error({unknown, Reason}) ->
 
 errormsg(String) ->
     io_lib:format("~s: ~ts", [?MODULE, String]).
+
 
 %% =====================================================================
 

--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -585,7 +585,8 @@ quick_macro_string(A) ->
     "(?" ++ atom_to_list(A) ++ ")".
 
 %% Skipping to the end of a macro call, tracking open/close constructs.
-%% @spec (Tokens) -> {Skipped, Rest}
+
+-spec skip_macro_args(Tokens :: term()) -> {Skipped :: list(), Rest :: term()}.
 
 skip_macro_args([{'(',_}=T | Ts]) ->
     skip_macro_args(Ts, [')'], [T]);

--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -609,7 +609,6 @@ filter_form({function, _, ?pp_form, _, [{clause, _, [], [], [{atom, _, kill}]}]}
 filter_form(T) ->
     T.
 
-
 %% ---------------------------------------------------------------------
 %% Normal parsing - try to preserve all information
 
@@ -1083,7 +1082,6 @@ format_error({unknown, Reason}) ->
 
 errormsg(String) ->
     io_lib:format("~s: ~ts", [?MODULE, String]).
-
 
 %% =====================================================================
 

--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -1185,10 +1185,10 @@ tokens_to_string([{var, _, A} | Ts]) ->
 tokens_to_string([{dot, _} | Ts]) ->
     ".\n" ++ tokens_to_string(Ts);
 % from OTP: -type af_sigil_prefix() :: {'sigil_prefix', anno(), atom()}.
-tokens_to_string([{sigil_prefix, _Prefix} | Ts]) ->
+tokens_to_string([{sigil_prefix, _, _Prefix} | Ts]) ->
     "" ++ tokens_to_string(Ts);
 % from OTP: -type af_sigil_suffix() :: {'sigil_suffix', anno(), string()}.
-tokens_to_string([{sigil_suffix, _Suffix} | Ts]) ->
+tokens_to_string([{sigil_suffix, _, _Suffix} | Ts]) ->
     "" ++ tokens_to_string(Ts);
 tokens_to_string([{A, _} | Ts]) ->
     atom_to_list(A) ++ " " ++ tokens_to_string(Ts);

--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -1,3 +1,4 @@
+%% erlfmt:ignore-begin
 %% =====================================================================
 %% %CopyrightBegin%
 %%
@@ -79,7 +80,6 @@
 %syntax tree is created, using the `m:erl_syntax` module.
 %""".
 
--format(ignore).
 -compile(nowarn_deprecated_catch).
 
 %% We have snake_case macros here
@@ -1219,3 +1219,4 @@ errormsg(String) ->
 reserved_word('else') -> true;
 reserved_word('maybe') -> true;
 reserved_word(Atom) -> erl_scan:f_reserved_word(Atom).
+%% erlfmt:ignore-end

--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -396,23 +396,22 @@ extract_escript_header(_) ->
     no_header.
 
 parse_form(Parser, Ts, L1, NoFail, Opt) ->
-    case catch {ok, Parser(Ts, Opt)} of
-        {'EXIT', Term} ->
-            {error, io_error(L1, {unknown, Term}), L1};
-        {error, Term} ->
+            case catch {ok, Parser(Ts, Opt)} of
+                {'EXIT', Term} ->
+                    {error, io_error(L1, {unknown, Term}), L1};
+                {error, Term} ->
             IoErr = io_error(L1, Term),
             {error, IoErr, L1};
-        {parse_error, _IoErr} when NoFail ->
-            {ok,
-             erl_syntax:set_pos(
-                 erl_syntax:text(tokens_to_string(Ts)),
-                 erl_anno:new(start_pos(Ts, L1))),
+                {parse_error, _IoErr} when NoFail ->
+            {ok, erl_syntax:set_pos(
+               erl_syntax:text(tokens_to_string(Ts)),
+               erl_anno:new(start_pos(Ts, L1))),
              L1};
-        {parse_error, IoErr} ->
+                {parse_error, IoErr} ->
             {error, IoErr, L1};
-        {ok, F} ->
-            {ok, F, L1}
-    end.
+                {ok, F} ->
+                    {ok, F, L1}
+            end.
 
 io_error(L, Desc) ->
     {L, ?MODULE, Desc}.
@@ -428,9 +427,11 @@ parse_tokens(Ts) ->
     parse_tokens(Ts, fun no_fix/1, fun fix_form/1, fun no_fix/1).
 
 
-%% @doc PreFix adjusts the tokens before parsing them.
-%%      FormFix adjusts the tokens after parsing them, if erl_parse failed.
-%%      PostFix adjusts the forms after parsing them, if erl_parse worked.
+%-doc """
+%PreFix adjusts the tokens before parsing them.
+%FormFix adjusts the tokens after parsing them, if erl_parse failed.
+%PostFix adjusts the forms after parsing them, if erl_parse worked.
+%""".
 parse_tokens(Ts, PreFix, FormFix, PostFix) ->
     case PreFix(Ts) of
         {form, Form} ->
@@ -458,9 +459,11 @@ parse_tokens(Ts, PreFix, FormFix, PostFix) ->
             end
     end.
 
-%% @doc This handles config files, app.src, etc.
-%%      PreFix adjusts the tokens before parsing them.
-%%      FormFix adjusts the tokens after parsing them, only if erl_parse failed.
+%-doc """
+%This handles config files, app.src, etc.
+%PreFix adjusts the tokens before parsing them.
+%FormFix adjusts the tokens after parsing them, only if erl_parse failed.
+%""".
 parse_tokens_as_terms(Ts, PreFix, FormFix) ->
     case PreFix(Ts) of
         {form, Form} ->
@@ -1004,9 +1007,10 @@ fix_contiguous_strings([Other | Rest], Ts) ->
 no_fix(_) ->
     no_fix.
 
-%%
-%% @doc Generates a string corresponding to the given token sequence.
-%% The string can be re-tokenized to yield the same token list again.
+%-doc """
+%Generates a string corresponding to the given token sequence.
+%The string can be re-tokenized to yield the same token list again.
+%""".
 token_to_string(T) ->
     case erl_scan:text(T) of
         undefined ->
@@ -1046,6 +1050,7 @@ token_to_string(Same, Same) ->
 %The string can be re-tokenized to yield the same token list again.
 %""".
 -spec tokens_to_string([term()]) -> string().
+
 tokens_to_string([{atom,_,A} | Ts]) ->
     io_lib:write_atom(A) ++ " " ++ tokens_to_string(Ts);
 tokens_to_string([{string, _, S} | Ts]) ->
@@ -1064,6 +1069,7 @@ tokens_to_string([{A, _} | Ts]) ->
     atom_to_list(A) ++ " " ++ tokens_to_string(Ts);
 tokens_to_string([]) ->
     "".
+
 
 %-doc false.
 -spec format_error(term()) -> string().

--- a/src/ktn_io_string.erl
+++ b/src/ktn_io_string.erl
@@ -114,7 +114,7 @@ get_until(Module, Function, XArgs, Str) ->
     apply_get_until(Module, Function, [], Str, XArgs).
 
 -spec apply_get_until(module(), atom(), any(), string() | eof, list()) ->
-                         {term(), string()}.
+    {term(), string()}.
 apply_get_until(Module, Function, State, String, XArgs) ->
     case apply(Module, Function, [State, String | XArgs]) of
         {done, Result, NewStr} ->
@@ -124,12 +124,12 @@ apply_get_until(Module, Function, State, String, XArgs) ->
     end.
 
 -spec skip(string() | {cont, integer(), string()}, term(), integer()) ->
-              {more, {cont, integer(), string()}} | {done, integer(), string()}.
+    {more, {cont, integer(), string()}} | {done, integer(), string()}.
 skip(Str, _Data, Length) ->
     skip(Str, Length).
 
 -spec skip(string() | {cont, integer(), string()}, integer()) ->
-              {more, {cont, integer(), string()}} | {done, integer(), string()}.
+    {more, {cont, integer(), string()}} | {done, integer(), string()}.
 skip(Str, Length) when is_list(Str) ->
     {more, {cont, Length, Str}};
 skip({cont, 0, Str}, Length) ->

--- a/test/files/otp27.erl
+++ b/test/files/otp27.erl
@@ -11,8 +11,11 @@ break() ->
       This is valid code.
     """),
 
-    Fun = fun () -> ok end,
-    ?assertMatch({ok, _}
-        when is_function(Fun, 0), {ok, 'no'}).
+    Fun = fun() -> ok end,
+    ?assertMatch(
+        {ok, _} when
+            is_function(Fun, 0),
+        {ok, 'no'}
+    ).
 
 -endif.

--- a/test/files/otp28.erl
+++ b/test/files/otp28.erl
@@ -1,0 +1,11 @@
+-module(otp28).
+
+-if(?OTP_RELEASE >= 28).
+
+-export([valid/0]).
+
+valid() ->
+    % zip generators
+    [A+B || A <- [1,2,3] && B <- [4,5,6]].
+
+-endif.

--- a/test/files/otp28.erl
+++ b/test/files/otp28.erl
@@ -24,7 +24,10 @@ valid() ->
     #{K => V + 1 || K := V <:- #{a => 1, b => 2}},
 
     % zip generators
-    [A + B || A <- [1, 2, 3] && B <- [4, 5, 6]].
+    [A + B || A <- [1, 2, 3] && B <- [4, 5, 6]],
+
+    % binaries
+    ~"This is a UTF-8 binary".
 
 %% erlfmt:ignore-end
 

--- a/test/files/otp28.erl
+++ b/test/files/otp28.erl
@@ -5,9 +5,20 @@
 -export([valid/0]).
 
 %% erlfmt:ignore-begin
+
 valid() ->
+    % list strict generator
+    [Integer || {Integer, _} <:- [{1, 2}, {3, 4}]],
+
+    % binary strict generator
+    [Word || <<Word:16>> <:= <<16#1234:16, 16#ABCD:16>>],
+
+    % map strict generator
+    #{K => V + 1 || K := V <:- #{a => 1, b => 2}},
+
     % zip generators
     [A + B || A <- [1, 2, 3] && B <- [4, 5, 6]].
+
 %% erlfmt:ignore-end
 
 -endif.

--- a/test/files/otp28.erl
+++ b/test/files/otp28.erl
@@ -27,7 +27,7 @@ valid() ->
     [A + B || A <- [1, 2, 3] && B <- [4, 5, 6]],
 
     % binaries
-    ~"This is a UTF-8 binary",
+    %~"This is a UTF-8 binary",
 
     % map comprehensions
     #{ K => V || K := V <- #{john => wick}}.

--- a/test/files/otp28.erl
+++ b/test/files/otp28.erl
@@ -2,10 +2,17 @@
 
 -if(?OTP_RELEASE >= 28).
 
+-moduledoc """
+Here we go
+""".
+
 -export([valid/0]).
 
 %% erlfmt:ignore-begin
 
+-doc """
+There and back again.
+""".
 valid() ->
     % list strict generator
     [Integer || {Integer, _} <:- [{1, 2}, {3, 4}]],

--- a/test/files/otp28.erl
+++ b/test/files/otp28.erl
@@ -27,7 +27,10 @@ valid() ->
     [A + B || A <- [1, 2, 3] && B <- [4, 5, 6]],
 
     % binaries
-    ~"This is a UTF-8 binary".
+    ~"This is a UTF-8 binary",
+
+    % map comprehensions
+    #{ K => V || K := V <- #{john => wick}}.
 
 %% erlfmt:ignore-end
 

--- a/test/files/otp28.erl
+++ b/test/files/otp28.erl
@@ -4,8 +4,10 @@
 
 -export([valid/0]).
 
+%% erlfmt:ignore-begin
 valid() ->
     % zip generators
-    [A+B || A <- [1,2,3] && B <- [4,5,6]].
+    [A + B || A <- [1, 2, 3] && B <- [4, 5, 6]].
+%% erlfmt:ignore-end
 
 -endif.

--- a/test/ktn_code_SUITE.erl
+++ b/test/ktn_code_SUITE.erl
@@ -18,7 +18,7 @@
 
 -if(?OTP_RELEASE >= 28).
 
--export([parse_zip/1]).
+-export([parse_generators/1]).
 
 -endif.
 -endif.
@@ -185,11 +185,11 @@ parse_sigils(_Config) ->
 
 -if(?OTP_RELEASE >= 28).
 
-parse_zip(_Config) ->
+parse_generators(_Config) ->
     {ok, _} =
         ktn_dodger:parse_file(
             "../../lib/katana_code/test/files/otp28.erl",
-            [no_fail, parse_macro_definitions]
+            [no_fail]
         ).
 
 -endif.

--- a/test/ktn_code_SUITE.erl
+++ b/test/ktn_code_SUITE.erl
@@ -1,8 +1,14 @@
 -module(ktn_code_SUITE).
 
 -export([all/0, init_per_suite/1, end_per_suite/1]).
--export([consult/1, beam_to_string/1, parse_tree/1, parse_tree_otp/1, latin1_parse_tree/1,
-         to_string/1]).
+-export([
+    consult/1,
+    beam_to_string/1,
+    parse_tree/1,
+    parse_tree_otp/1,
+    latin1_parse_tree/1,
+    to_string/1
+]).
 
 -export([parse_maybe/1, parse_maybe_else/1]).
 
@@ -87,11 +93,15 @@ beam_to_string(_Config) ->
 -spec parse_tree(config()) -> ok.
 parse_tree(_Config) ->
     ModuleNode =
-        #{type => module,
-          attrs =>
-              #{location => {1, 2},
-                text => "module",
-                value => x}},
+        #{
+            type => module,
+            attrs =>
+                #{
+                    location => {1, 2},
+                    text => "module",
+                    value => x
+                }
+        },
 
     #{type := root, content := _} = ktn_code:parse_tree("-module(x)."),
 
@@ -124,9 +134,11 @@ latin1_parse_tree(_Config) ->
                 error
         end,
     #{type := root, content := _} =
-        ktn_code:parse_tree(<<"%% -*- coding: latin-1 -*-\n"
-                              "%% �"
-                              "-module(x).">>),
+        ktn_code:parse_tree(<<
+            "%% -*- coding: latin-1 -*-\n"
+            "%% �"
+            "-module(x)."
+        >>),
 
     ok.
 
@@ -141,9 +153,11 @@ to_string(_Config) ->
 -spec parse_maybe(config()) -> ok.
 parse_maybe(_Config) ->
     %% Note that to pass this test case, the 'maybe_expr' feature must be enabled.
-    #{type := root,
-      content :=
-          [#{type := function, content := [#{type := clause, content := [#{type := 'maybe'}]}]}]} =
+    #{
+        type := root,
+        content :=
+            [#{type := function, content := [#{type := clause, content := [#{type := 'maybe'}]}]}]
+    } =
         ktn_code:parse_tree(<<"foo() -> maybe ok ?= ok end.">>),
 
     ok.
@@ -151,9 +165,11 @@ parse_maybe(_Config) ->
 -spec parse_maybe_else(config()) -> ok.
 parse_maybe_else(_Config) ->
     %% Note that to pass this test case, the 'maybe_expr' feature must be enabled.
-    #{type := root,
-      content :=
-          [#{type := function, content := [#{type := clause, content := [#{type := 'maybe'}]}]}]} =
+    #{
+        type := root,
+        content :=
+            [#{type := function, content := [#{type := clause, content := [#{type := 'maybe'}]}]}]
+    } =
         ktn_code:parse_tree(<<"foo() -> maybe ok ?= ok else _ -> ng end.">>),
 
     ok.
@@ -162,15 +178,19 @@ parse_maybe_else(_Config) ->
 
 parse_sigils(_Config) ->
     {ok, _} =
-        ktn_dodger:parse_file("../../lib/katana_code/test/files/otp27.erl",
-                              [no_fail, parse_macro_definitions]).
+        ktn_dodger:parse_file(
+            "../../lib/katana_code/test/files/otp27.erl",
+            [no_fail, parse_macro_definitions]
+        ).
 
 -if(?OTP_RELEASE >= 28).
 
 parse_zip(_Config) ->
     {ok, _} =
-        ktn_dodger:parse_file("../../lib/katana_code/test/files/otp28.erl",
-                              [no_fail, parse_macro_definitions]).
+        ktn_dodger:parse_file(
+            "../../lib/katana_code/test/files/otp28.erl",
+            [no_fail, parse_macro_definitions]
+        ).
 
 -endif.
 -endif.

--- a/test/ktn_code_SUITE.erl
+++ b/test/ktn_code_SUITE.erl
@@ -4,15 +4,12 @@
 -export([consult/1, beam_to_string/1, parse_tree/1, parse_tree_otp/1, latin1_parse_tree/1,
          to_string/1]).
 
--if(?OTP_RELEASE >= 25).
-
 -export([parse_maybe/1, parse_maybe_else/1]).
 
 -if(?OTP_RELEASE >= 27).
 
 -export([parse_sigils/1]).
 
--endif.
 -endif.
 
 -define(EXCLUDED_FUNS, [module_info, all, test, init_per_suite, end_per_suite]).
@@ -136,8 +133,6 @@ to_string(_Config) ->
 
     ok.
 
--if(?OTP_RELEASE >= 25).
-
 -spec parse_maybe(config()) -> ok.
 parse_maybe(_Config) ->
     %% Note that to pass this test case, the 'maybe_expr' feature must be enabled.
@@ -165,7 +160,6 @@ parse_sigils(_Config) ->
         ktn_dodger:parse_file("../../lib/katana_code/test/files/otp27.erl",
                               [no_fail, parse_macro_definitions]).
 
--endif.
 -endif.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/test/ktn_code_SUITE.erl
+++ b/test/ktn_code_SUITE.erl
@@ -10,6 +10,11 @@
 
 -export([parse_sigils/1]).
 
+-if(?OTP_RELEASE >= 28).
+
+-export([parse_zip/1]).
+
+-endif.
 -endif.
 
 -define(EXCLUDED_FUNS, [module_info, all, test, init_per_suite, end_per_suite]).
@@ -160,6 +165,14 @@ parse_sigils(_Config) ->
         ktn_dodger:parse_file("../../lib/katana_code/test/files/otp27.erl",
                               [no_fail, parse_macro_definitions]).
 
+-if(?OTP_RELEASE >= 28).
+
+parse_zip(_Config) ->
+    {ok, _} =
+        ktn_dodger:parse_file("../../lib/katana_code/test/files/otp28.erl",
+                              [no_fail, parse_macro_definitions]).
+
+-endif.
 -endif.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
~I add the minimum requirements to have `elvis_core` not throw (and parse) for upcoming rule change `operator_spaces` (around `<:=` and `<:-`, for lists, binaries and maps)~

~We could think about moving `minimum_otp_vsn` to 26, now that 28 is out.~

I changed the scope of the PR (was what is now struck through; now is what the title states) following discussions around preferences. I'll move it to draft until I have time to work on more changes.

Fix #89.

# The process

For future reference:

1. I copied `epp_dodger` from the latest stable Erlang/OTP (28.0 at this moment) over `ktn_dodger` and adjusted (take care to not ruin the "format" in place - eases review?).
2. I made sure `rebar3 test` was ✅ 
3. I `rebar3_fmt`'ed it
4. I added some tests for newer syntax
5. I checked changes to `absform.md` (https://github.com/erlang/otp/blob/master/erts/doc/guides/absform.md) and the mentioned modules:
- [x] `epp`
- [x] `erl_eval`
- [x] `erl_lint`
- [x] `erl_parse`
- [x] `erl_pp`
- [x] `absform.md` ℹ️ this was possibly the most useful of the bunch
6. I checked changes to:
- [x] `erl_syntax` 
- [x] `erl_prettypr`
7. I ran a test, mentioned below, on the whole of OTP's codebase to find exceptions

Interesting commits:

- [46f1495](https://github.com/erlang/otp/commit/46f149593e6727d1e1c6d167ab0e2d73062e0027): strict generators
- [899322d](https://github.com/erlang/otp/commit/899322d9f8814900b97b362bab09b2c0e85cd62b): zip generators
- [f2f48e3](https://github.com/erlang/otp/commit/f2f48e329827b1750a39cced3cd4a27183e944af): moduledoc/doc