### PR TITLE
fix: Add missing `epp_dodger` compare details

### DIFF
--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -793,7 +793,10 @@ macro_call([{'(', _} | Args], Anno, {_, AnnoN, _} = N, Rest, As, Opt) ->
     %% note that we must scan the argument list; it may not be skipped
     do_scan_macros(Args1 ++ [{'}', AnnoN} | Close],
                   Rest,
-                  lists:reverse(Open ++ [{'{', Anno}, {atom, Anno, ?macro_call}, {',', Anno}, N, {',', AnnoN}], As),
+                  lists:reverse(
+                    Open ++
+                    [{'{', Anno}, {atom, Anno, ?macro_call}, {',', Anno}, N, {',', AnnoN}],
+                    As),
                   Opt).
 
 macro_atom(atom, A) ->

--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -777,6 +777,7 @@ macro_call([{'(', _}, {')', _}], Anno, {_, AnnoN, _} = N, Rest, As, Opt) ->
     {Open, Close} = parentheses(As),
     do_scan_macros([],
                   Rest,
+                  %% {'?macro_call', N }
                   lists:reverse(
                     Open ++
                     [{'{', Anno}, {atom, Anno, ?macro_call}, {',', Anno}, N, {'}', AnnoN}] ++
@@ -793,6 +794,7 @@ macro_call([{'(', _} | Args], Anno, {_, AnnoN, _} = N, Rest, As, Opt) ->
     %% note that we must scan the argument list; it may not be skipped
     do_scan_macros(Args1 ++ [{'}', AnnoN} | Close],
                   Rest,
+                  %% {'?macro_call', N, Arg1, ... }
                   lists:reverse(
                     Open ++
                     [{'{', Anno}, {atom, Anno, ?macro_call}, {',', Anno}, N, {',', AnnoN}],

--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -663,13 +663,8 @@ default_prefix(#opt{parse_macro_definitions = false, compact_strings = true}) ->
     end.
 
 scan_form([{'-', _Anno}, {atom, AnnoA, define} | Ts], #opt{parse_macro_definitions = false}) ->
-    [
-        {atom, AnnoA, ?pp_form},
-        {'(', AnnoA},
-        {')', AnnoA},
-        {'->', AnnoA},
-        {atom, AnnoA, define}
-    | Ts];
+    [{atom, AnnoA, ?pp_form}, {'(', AnnoA}, {')', AnnoA}, {'->', AnnoA}, {atom, AnnoA, define}
+     | Ts];
 scan_form([{'-', _Anno}, {atom, AnnoA, define} | Ts], Opt) ->
     [{atom, AnnoA, ?pp_form}, {'(', AnnoA}, {')', AnnoA}, {'->', AnnoA}, {atom, AnnoA, define}
      | scan_macros(Ts, Opt)];


### PR DESCRIPTION
Here's material for 2.4.1 😄 

~Don't merge yet as I work out if the changes that make the tests fail are warranted.~

I improved my process (and documented it in the pull request, for future reference). I locally format both files and then compare the formatted versions (even if I import stuff by hand).

There's still some stuff that's difficult to compare, even if formatted (like the stuff in this pull request - where it's all about details) but at least it's passing `elvis_core`'s tests.