### PR TITLE
Don't crash on multiline sigils in OTP26

### DIFF
--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -1009,6 +1009,8 @@ token_to_string(atom, A) ->
     io_lib:write_atom(A);
 token_to_string(string, S) ->
     io_lib:write_string(S);
+token_to_string(string_concat, S) ->
+    io_lib:write_string(S);
 token_to_string(char, C) ->
     io_lib:write_char(C);
 token_to_string(float, F) ->


### PR DESCRIPTION
This comes from here: https://github.com/inaka/elvis_core/pull/599#issuecomment-4030167547