### PR TITLE
Fix #96: Remove old catch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         otp: ['26', '27', '28']
-        rebar: ['3.25']
+        rebar: ['3.27']
 
     steps:
       - uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
       - name: Compile
         run: ERL_FLAGS="-enable-feature all" rebar3 compile
       - name: Format check
-        if: matrix.otp == '27'
+        if: matrix.otp >= '27'
         run: rebar3 fmt --check
       - name: Run tests and verifications (features not enabled)
         run: rebar3 test

--- a/elvis.config
+++ b/elvis.config
@@ -6,7 +6,9 @@
                 filter => "*.erl",
                 ruleset => erl_files,
                 rules => [
-                    {elvis_style, atom_naming_convention, #{regex => "^([a-z][A-Za-z0-9]*_?)*$"}}
+                    {elvis_style, atom_naming_convention, #{regex => "^([a-z][A-Za-z0-9]*_?)*$"}},
+                    {elvis_style, private_data_types, #{apply_to => [record]}},
+                    {elvis_style, no_deep_nesting, #{level => 5}}
                 ]
             },
             #{

--- a/rebar.config
+++ b/rebar.config
@@ -11,11 +11,11 @@
 %% == Dependencies and plugins ==
 
 {project_plugins, [
-    {rebar3_hank, "~> 1.4.0"},
-    {rebar3_hex, "~> 7.0.7"},
-    {erlfmt, "~> 1.6.2"},
-    {rebar3_lint, "~> 3.1.0"},
-    {rebar3_ex_doc, "~> 0.2.20"}
+    {rebar3_hank, "~> 1.6.1"},
+    {rebar3_hex, "~> 7.1.0"},
+    {erlfmt, "~> 1.8.0"},
+    {rebar3_lint, "~> 4.2.3"},
+    {rebar3_ex_doc, "~> 0.2.31"}
 ]}.
 
 %% == Documentation ==

--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -96,6 +96,12 @@
 %% The following should be: 1) pseudo-uniquely identifiable, and 2)
 %% cause nice looking error messages when the parser has to give up.
 
+%% We use some very weird macros here, because this module was copied from epp_dodger
+-elvis([{elvis_style, macro_naming_convention, disable}]).
+
+%% PreFix is not the same as Prefix
+-elvis([{elvis_style, variable_casing, disable}]).
+
 -define(macro_call, '? <macro> (').
 -define(atom_prefix, "? ").
 -define(var_prefix, "?,").

--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -380,22 +380,23 @@ extract_escript_header(_) ->
     no_header.
 
 parse_form(Parser, Ts, L1, NoFail, Opt) ->
-    case catch {ok, Parser(Ts, Opt)} of
-        {'EXIT', Term} ->
-            {error, io_error(L1, {unknown, Term}), L1};
-        {error, Term} ->
+    try Parser(Ts, Opt) of
+        F ->
+            {ok, F, L1}
+    catch
+        throw:{error, Term} ->
             IoErr = io_error(L1, Term),
             {error, IoErr, L1};
-        {parse_error, _IoErr} when NoFail ->
+        throw:{parse_error, _IoErr} when NoFail ->
             {ok,
              erl_syntax:set_pos(
                  erl_syntax:text(tokens_to_string(Ts)),
                  erl_anno:new(start_pos(Ts, L1))),
              L1};
-        {parse_error, IoErr} ->
+        throw:{parse_error, IoErr} ->
             {error, IoErr, L1};
-        {ok, F} ->
-            {ok, F, L1}
+        _:Term ->
+            {error, io_error(L1, {unknown, Term}), L1}
     end.
 
 io_error(L, Desc) ->

--- a/src/ktn_io_string.erl
+++ b/src/ktn_io_string.erl
@@ -50,6 +50,8 @@ loop(#{buffer := Str} = State) ->
             ?MODULE:loop(NewState);
         _Unknown ->
             ?MODULE:loop(State)
+    after 60000 ->
+        exit(timeout)
     end.
 
 -spec reply(pid(), pid(), any()) -> any().

--- a/test/files/otp27.erl
+++ b/test/files/otp27.erl
@@ -7,9 +7,11 @@
 -export([break/0]).
 
 break() ->
-    _ = scan:string(~"""
+    _ = scan:string(
+        ~"""
       This is valid code.
-    """),
+    """
+    ),
 
     Fun = fun() -> ok end,
     ?assertMatch(


### PR DESCRIPTION
Removal of old-style `catch`, plus plugin updates.