### PR TITLE
Fix parsing of type definitions that contain macros

### DIFF
--- a/src/ktn_code.erl
+++ b/src/ktn_code.erl
@@ -140,7 +140,7 @@ revert(attribute, Node0) ->
 
     Args = erl_syntax:attribute_arguments(Node),
     Pos = erl_syntax:get_pos(Node),
-    {attribute, Pos, Name, Args};
+    {attribute, Pos, Name, attribute_value(Name, Args)};
 revert(macro, Node0) ->
     Subs = erl_syntax:subtrees(Node0),
     Gs = [[erl_syntax:revert(X) || X <- L] || L <- Subs],
@@ -154,6 +154,25 @@ revert(_, Node) ->
     %% When a node can't be reverted we avoid failing by returning
     %% the a node for the atom 'non_reversible_form'
     {atom, [{node, Node}], non_reversible_form}.
+
+%% A `-type'/`-opaque'/`-nominal' definition whose body contains a macro cannot
+%% be reverted by erl_syntax into the usual `{Name, Type, Params}' form, so it
+%% arrives here as a single tuple argument encoding that triple. Normalise it
+%% back to the 3-tuple so `to_map/1' classifies it consistently (e.g. `-type' as
+%% `type_attr' rather than the raw `type') and callers get a stable value shape.
+attribute_value(Kind, [{tuple, _, [{atom, _, Name}, Type, Params]}]) when
+    Kind =:= type; Kind =:= opaque; Kind =:= nominal
+->
+    {Name, Type, cons_to_list(Params)};
+attribute_value(_Kind, Args) ->
+    Args.
+
+cons_to_list({nil, _}) ->
+    [];
+cons_to_list({cons, _, Head, Tail}) ->
+    [Head | cons_to_list(Tail)];
+cons_to_list(Other) ->
+    [Other].
 
 token_to_map({Type, Attrs}) ->
     #{type => Type, attrs => #{text => get_text(Attrs), location => get_location(Attrs)}};
@@ -983,12 +1002,19 @@ to_map({macro, Attrs, Name, Args}) ->
                 Args
         end,
     NameStr = macro_name(Name),
+    Text =
+        case get_text(Attrs) of
+            undefined ->
+                "";
+            T ->
+                T
+        end,
     #{
         type => macro,
         attrs =>
             #{
                 location => get_location(Attrs),
-                text => get_text(Attrs) ++ NameStr,
+                text => Text ++ NameStr,
                 name => NameStr
             },
         content => to_map(Args1)

--- a/test/ktn_code_SUITE.erl
+++ b/test/ktn_code_SUITE.erl
@@ -8,6 +8,7 @@
     parse_tree/1,
     parse_tree_otp/1,
     latin1_parse_tree/1,
+    parse_macro_in_type/1,
     to_string/1
 ]).
 
@@ -19,7 +20,7 @@
 
 -if(?OTP_RELEASE >= 28).
 
--export([parse_generators/1]).
+-export([parse_generators/1, parse_macro_in_nominal/1]).
 
 -endif.
 -endif.
@@ -320,12 +321,58 @@ parse_generators(_Config) ->
             [no_fail]
         ).
 
+-spec parse_macro_in_nominal(config()) -> ok.
+parse_macro_in_nominal(_Config) ->
+    %% A macro in a `-nominal' body must still classify as `nominal' and expose
+    %% the `{Name, Type, Params}' value rather than a raw token list, including
+    %% with multiple, deeply nested macros.
+    #{type := nominal, attrs := #{value := {my_nominal, _, []}}} =
+        type_def_node(<<"-nominal my_nominal() :: {?MODULE, list()}.">>),
+    #{type := nominal, attrs := #{value := {nested, _, []}}} =
+        type_def_node(<<"-nominal nested() :: {?A, [?B], #{?C => ?D}}.">>),
+    ok.
+
 -endif.
 -endif.
+
+-spec parse_macro_in_type(config()) -> ok.
+parse_macro_in_type(_Config) ->
+    %% A macro in a type body must still classify the attribute correctly (so
+    %% `-type' stays `type_attr', not the raw `type') and expose a stable
+    %% `{Name, Type, Params}' value instead of a raw token list.
+    #{type := type_attr, attrs := #{name := my_type}} =
+        type_def_node(<<"-type my_type() :: {?MODULE, list()}.">>),
+    #{type := opaque, attrs := #{value := {my_opaque, _, []}}} =
+        type_def_node(<<"-opaque my_opaque() :: {?MODULE, list()}.">>),
+    %% The normalisation is driven by the shape erl_syntax produces for any
+    %% macro-in-body type, so it holds no matter how many macros appear, how
+    %% deeply they nest, or whether they sit in tuples, lists, maps (incl. as
+    %% keys), remote types, or macro calls.
+    Bodies = [
+        <<"{?MODULE, [?MODULE], #{?MODULE => ?MODULE}}">>,
+        <<"#{?KEY := value, key := ?VALUE}">>,
+        <<"?MOD:remote()">>,
+        <<"?WRAP({?MODULE, list()})">>,
+        <<"[?A | ?B]">>
+    ],
+    lists:foreach(
+        fun(Body) ->
+            Source = <<"-opaque o() :: ", Body/binary, $.>>,
+            #{type := opaque, attrs := #{value := {o, _, []}}} = type_def_node(Source)
+        end,
+        Bodies
+    ),
+    ok.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Helper
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+type_def_node(Source) ->
+    #{content := Content} = ktn_code:parse_tree(Source),
+    [Node] =
+        [N || N <- Content, lists:member(ktn_code:type(N), [type_attr, type, opaque, nominal])],
+    Node.
 
 -spec shuffle([string()]) -> [[any()]].
 shuffle(List) ->


### PR DESCRIPTION
A `-type`/`-opaque`/`-nominal` whose body contains a macro couldn't be reverted into the usual `{Name, Type, Params}` form, so it surfaced as a raw token list.

For example, Elvis's `max_map_type_keys` rule, on `-nominal cmd() :: {?MODULE, list()}.`, fails with the following (the filter expected a `{_Name, TypeAST, _Params}` tuple but got the raw list):

```erlang
{badmatch, [{tuple, [{text,"nominal"},{location,{48,2}}],
             [{atom,0,cmd}, {tuple,0,[{atom,0,type}, {cons,0, ...}]}]}],
 is_map_opaque_or_nominal_with_atom_keys,
 max_map_type_keys_on_opaques_and_nominals,
 max_map_type_keys, ...}
```