### PR TITLE
Add support for OTP 29

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        otp: ['26', '27', '28']
+        otp: ['27', '28', '29']
         rebar: ['3.27']
 
     steps:

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [warn_unused_import, warn_export_vars, warnings_as_errors, verbose, report, debug_info]}.
 
-{minimum_otp_vsn, "26"}.
+{minimum_otp_vsn, "27"}.
 
 {profiles, [{test, [{cover_enabled, true}, {cover_opts, [verbose]}, {ct_opts, [{verbose, true}]}]}]}.
 

--- a/src/ktn_dodger.erl
+++ b/src/ktn_dodger.erl
@@ -80,7 +80,7 @@
 %syntax tree is created, using the `m:erl_syntax` module.
 %""".
 
--compile(nowarn_deprecated_catch).
+-compile([{nowarn_possibly_unsafe_function, {erlang, list_to_atom, 1}}, nowarn_deprecated_catch]).
 
 %% We have snake_case macros here
 -elvis([{elvis_style, macro_names, disable}]).

--- a/test/files/otp29.erl
+++ b/test/files/otp29.erl
@@ -4,13 +4,13 @@
 
 -export([valid/0]).
 
+%% erlfmt:ignore-begin
+
 %% native record declaration (no parentheses, hash before name)
 -record #point{x :: integer(), y :: integer()}.
 
 %% nominal type
 -nominal meters() :: number().
-
-%% erlfmt:ignore-begin
 
 valid() ->
     %% comprehension assignment (compr_assign experimental feature)

--- a/test/files/otp29.erl
+++ b/test/files/otp29.erl
@@ -9,13 +9,10 @@
 %% native record declaration (no parentheses, hash before name)
 -record #point{x :: integer(), y :: integer()}.
 
-%% nominal type
--nominal meters() :: number().
-
 valid() ->
     %% comprehension assignment (compr_assign experimental feature)
     Pairs = [{1, a}, {2, b}, {3, c}],
-    [N || {N, _} = _Pair <- Pairs],
+    [N || Pair <- Pairs, N = element(1, Pair)],
 
     %% native record construction
     _P = #point{x = 1, y = 2},

--- a/test/files/otp29.erl
+++ b/test/files/otp29.erl
@@ -1,0 +1,26 @@
+-module(otp29).
+
+-if(?OTP_RELEASE >= 29).
+
+-export([valid/0]).
+
+%% native record declaration (no parentheses, hash before name)
+-record #point{x :: integer(), y :: integer()}.
+
+%% nominal type
+-nominal meters() :: number().
+
+%% erlfmt:ignore-begin
+
+valid() ->
+    %% comprehension assignment (compr_assign experimental feature)
+    Pairs = [{1, a}, {2, b}, {3, c}],
+    [N || {N, _} = _Pair <- Pairs],
+
+    %% native record construction
+    _P = #point{x = 1, y = 2},
+    ok.
+
+%% erlfmt:ignore-end
+
+-endif.

--- a/test/ktn_code_SUITE.erl
+++ b/test/ktn_code_SUITE.erl
@@ -22,6 +22,11 @@
 
 -export([parse_generators/1, parse_macro_in_nominal/1]).
 
+-if(?OTP_RELEASE >= 29).
+
+-export([parse_native_record/1]).
+
+-endif.
 -endif.
 -endif.
 
@@ -332,6 +337,16 @@ parse_macro_in_nominal(_Config) ->
         type_def_node(<<"-nominal nested() :: {?A, [?B], #{?C => ?D}}.">>),
     ok.
 
+-if(?OTP_RELEASE >= 29).
+
+parse_native_record(_Config) ->
+    {ok, _} =
+        ktn_dodger:parse_file(
+            "../../lib/katana_code/test/files/otp29.erl",
+            [no_fail, parse_macro_definitions]
+        ).
+
+-endif.
 -endif.
 -endif.
 

--- a/test/ktn_code_SUITE.erl
+++ b/test/ktn_code_SUITE.erl
@@ -24,7 +24,7 @@
 
 -if(?OTP_RELEASE >= 29).
 
--export([parse_native_record/1]).
+-export([otp29_features/1]).
 
 -endif.
 -endif.
@@ -339,7 +339,11 @@ parse_macro_in_nominal(_Config) ->
 
 -if(?OTP_RELEASE >= 29).
 
-parse_native_record(_Config) ->
+otp29_features(_Config) ->
+    %% Native record declaration maps to type `native_record' with a `{Name, Fields}' value.
+    #{type := native_record, attrs := #{value := {point, _}}} =
+        native_record_node(<<"-record #point{x :: integer(), y :: integer()}.">>),
+    %% The full fixture file (native records + compr_assign comprehension) must parse cleanly.
     {ok, _} =
         ktn_dodger:parse_file(
             "../../lib/katana_code/test/files/otp29.erl",
@@ -388,6 +392,15 @@ type_def_node(Source) ->
     [Node] =
         [N || N <- Content, lists:member(ktn_code:type(N), [type_attr, type, opaque, nominal])],
     Node.
+
+-if(?OTP_RELEASE >= 29).
+
+native_record_node(Source) ->
+    #{content := Content} = ktn_code:parse_tree(Source),
+    [Node] = [N || N <- Content, ktn_code:type(N) =:= native_record],
+    Node.
+
+-endif.
 
 -spec shuffle([string()]) -> [[any()]].
 shuffle(List) ->


### PR DESCRIPTION
Hi @elbrujohalcon -- I'm not too familiar with erlang but this is affecting us downstream in [aws_credentials](https://github.com/aws-beam/aws_credentials/issues/98) so I tried pointing Claude at it. Hopefully this closes #101. Tested with `rebar3 ct compile lint xref dialyzer cover`. Let me know if there's any additional information or validation you'd like to see. Thanks!